### PR TITLE
Add more granurality to errors.

### DIFF
--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -258,11 +258,7 @@ module Twilio
           end
         end
         if response.kind_of? Net::HTTPClientError
-          case object['code']
-            when 21401 then raise Twilio::REST::InvalidNumber, object['message']
-            when 21408 then raise Twilio::REST::InternationalSmsUnavailable, object['message']
-            else raise Twilio::REST::RequestError, object['message']
-            end
+          raise Twilio::REST::RequestError.exception(object['message'], object['code'])
         end
         object
       end

--- a/lib/twilio-ruby/rest/errors.rb
+++ b/lib/twilio-ruby/rest/errors.rb
@@ -1,8 +1,13 @@
 module Twilio
   module REST
     class ServerError < StandardError; end
-    class RequestError < StandardError; end
-    class InvalidNumber < RequestError; end
-    class InternationalSmsUnavailable < RequestError; end
+
+    class RequestError< StandardError
+      attr_reader :code
+      def initialize(msg, code=nil);
+        super(msg);
+        @code = code;
+      end
+    end
   end
 end


### PR DESCRIPTION
Greetings,

I was thinking that it would be nice to have more granularity in the exceptions raised by the twilio-ruby gem. For instance, you could add specific errors  for invalid number or international calls not available.

I made a small commit to show you this idea. I could add others as well :) 

What do you think? 
