### PR TITLE
Use built-in respond_to matcher

### DIFF
--- a/spec/rest/account_spec.rb
+++ b/spec/rest/account_spec.rb
@@ -7,52 +7,52 @@ describe Twilio::REST::Account do
   end
 
   it 'sets up incoming phone numbers resources object' do
-    @account.respond_to?(:incoming_phone_numbers).should == true
+    @account.should respond_to(:incoming_phone_numbers)
     @account.incoming_phone_numbers.instance_variable_get('@uri').should == 'someUri/IncomingPhoneNumbers'
   end
 
   it 'sets up an available phone numbers resources object' do
-    @account.respond_to?(:available_phone_numbers).should == true
+    @account.should respond_to(:available_phone_numbers)
     @account.available_phone_numbers.instance_variable_get('@uri').should == 'someUri/AvailablePhoneNumbers'
   end
 
   it 'sets up an outgoing caller ids resources object' do
-    @account.respond_to?(:outgoing_caller_ids).should == true
+    @account.should respond_to(:outgoing_caller_ids)
     @account.outgoing_caller_ids.instance_variable_get('@uri').should == 'someUri/OutgoingCallerIds'
   end
 
   it 'sets up a calls resources object' do
-    @account.respond_to?(:calls).should == true
+    @account.should respond_to(:calls)
     @account.calls.instance_variable_get('@uri').should == 'someUri/Calls'
   end
 
   it 'sets up a conferences resources object' do
-    @account.respond_to?(:conferences).should == true
+    @account.should respond_to(:conferences)
     @account.conferences.instance_variable_get('@uri').should == 'someUri/Conferences'
   end
 
   it 'sets up a queues resources object' do
-    @account.respond_to?(:queues).should == true
+    @account.should respond_to(:queues)
     @account.queues.instance_variable_get('@uri').should == 'someUri/Queues'
   end
 
   it 'sets up a sms resource object' do
-    @account.respond_to?(:sms).should == true
+    @account.should respond_to(:sms)
     @account.sms.instance_variable_get('@uri').should == 'someUri/SMS'
   end
 
   it 'sets up a recordings resources object' do
-    @account.respond_to?(:recordings).should == true
+    @account.should respond_to(:recordings)
     @account.recordings.instance_variable_get('@uri').should == 'someUri/Recordings'
   end
 
   it 'sets up a transcriptions resources object' do
-    @account.respond_to?(:transcriptions).should == true
+    @account.should respond_to(:transcriptions)
     @account.transcriptions.instance_variable_get('@uri').should == 'someUri/Transcriptions'
   end
 
   it 'sets up a notifications resources object' do
-    @account.respond_to?(:notifications).should == true
+    @account.should respond_to(:notifications)
     @account.notifications.instance_variable_get('@uri').should == 'someUri/Notifications'
   end
 end

--- a/spec/rest/call_spec.rb
+++ b/spec/rest/call_spec.rb
@@ -7,12 +7,12 @@ describe Twilio::REST::Call do
   end
 
   it 'sets up a recordings resources object' do
-    @call.respond_to?(:recordings).should == true
+    @call.should respond_to(:recordings)
     @call.recordings.instance_variable_get('@uri').should == 'someUri/Recordings'
   end
 
   it 'sets up a notifications resources object' do
-    @call.respond_to?(:notifications).should == true
+    @call.should respond_to(:notifications)
     @call.notifications.instance_variable_get('@uri').should == 'someUri/Notifications'
   end
 end

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -77,13 +77,13 @@ describe Twilio::REST::Client do
 
   it 'should set up an accounts resources object' do
     twilio = Twilio::REST::Client.new('someSid', 'someToken')
-    twilio.respond_to?(:accounts).should == true
+    twilio.should respond_to(:accounts)
     twilio.accounts.instance_variable_get('@uri').should == '/2010-04-01/Accounts'
   end
 
   it 'should set up an account object with the given sid' do
     twilio = Twilio::REST::Client.new('someSid', 'someToken')
-    twilio.respond_to?(:account).should == true
+    twilio.should respond_to(:account)
     twilio.account.instance_variable_get('@uri').should == '/2010-04-01/Accounts/someSid'
   end
 

--- a/spec/rest/conference_spec.rb
+++ b/spec/rest/conference_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Twilio::REST::Conference do
   it 'should set up a participants resources object' do
     conference = Twilio::REST::Conference.new('someUri', 'someClient')
-    conference.respond_to?(:participants).should == true
+    conference.should respond_to(:participants)
     conference.participants.instance_variable_get('@uri').should == 'someUri/Participants'
   end
 end

--- a/spec/rest/queue_spec.rb
+++ b/spec/rest/queue_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Twilio::REST::Queue do
   it 'should set up a members resources object' do
     queue = Twilio::REST::Queue.new('someUri', 'someClient')
-    queue.respond_to?(:members).should == true
+    queue.should respond_to(:members)
     queue.members.instance_variable_get('@uri').should == 'someUri/Members'
   end
 end

--- a/spec/rest/recording_spec.rb
+++ b/spec/rest/recording_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Twilio::REST::Recording do
   it 'should set up a transcriptions resources object' do
     call = Twilio::REST::Recording.new('someUri', 'someClient')
-    call.respond_to?(:transcriptions).should == true
+    call.should respond_to(:transcriptions)
     call.transcriptions.instance_variable_get('@uri').should == 'someUri/Transcriptions'
   end
 end


### PR DESCRIPTION
Its more natural to read using the built-in matcher. Also it clarifies the intent of the expectation.

I'd love to get feedback from you if you need me to change anything before you can merge.
