### PR TITLE
Corrections to the ruby documentation

### DIFF
--- a/docs/_themes/kr/layout.html
+++ b/docs/_themes/kr/layout.html
@@ -12,7 +12,7 @@
     <div class="footer">
       &copy; Copyright {{ copyright }}.
     </div>
-    <a href="https://github.com/twilio/twilio-python">
+    <a href="https://github.com/twilio/twilio-ruby">
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" />
     </a>
     <script type="text/javascript">

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -19,7 +19,7 @@ Make a Call
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @call = @client.calls.create({:to => "9991231234", :from => "9991231234",
+    @call = @client.account.calls.create({:to => "9991231234", :from => "9991231234",
         :url => "http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient"})
     puts @call.length
     puts @call.sid
@@ -38,7 +38,7 @@ Send an SMS
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @message = client.messages.create({:to => "+12316851234",
+    @message = @client.account.messages.create({:to => "+12316851234",
                                        :from => "+15555555555",
                                        :body => "Hello there!"})
 
@@ -56,7 +56,7 @@ Send an MMS
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @message = client.messages.create({:to => "+15558676309",
+    @message = @client.account.messages.create({:to => "+15558676309",
                                        :from => "+15555555555",
                                        :body => "Jenny I need you!",
                                        :media_url => "http://twilio.com/heart.jpg"})

--- a/docs/usage/applications.rst
+++ b/docs/usage/applications.rst
@@ -26,7 +26,7 @@ The following code will print out the :attr:`friendly_name` for each :class:`App
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @client.applications.each do |app|
+    @client.account.applications.each do |app|
         puts app.friendly_name
     end
 
@@ -45,7 +45,7 @@ You can filter applications by FriendlyName
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @client.applications.list({:friendly_name => 'FOO'})}.each do |app|
+    @client.account.applications.list({:friendly_name => 'FOO'})}.each do |app|
         puts app.sid
     end
 
@@ -66,7 +66,7 @@ accepts many other arguments for url configuration.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @application = @client.applications.create({:friendly_name => "My New App"})
+    @application = @client.account.applications.create({:friendly_name => "My New App"})
 
 
 Updating an Application
@@ -85,7 +85,7 @@ Updating an Application
     url = "http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient"
     app_sid = 'AP123' # the app you'd like to update
 
-    @application = @client.applications.get(app_sid)
+    @application = @client.account.applications.get(app_sid)
     @application.update({:voice_url => url})
 
 
@@ -103,6 +103,6 @@ Deleting an Application
     @client = Twilio::REST::Client.new account_sid, auth_token
 
     app_sid = 'AP123' # the app you'd like to delete
-    @client.applications.get(app_sid)
+    @client.account.applications.get(app_sid)
     @application.delete()
 

--- a/docs/usage/basics.rst
+++ b/docs/usage/basics.rst
@@ -43,12 +43,12 @@ The :class:`Client` gives you access to various list resources.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @calls = client.calls.list()
+	@calls = @client.account.calls.list()
 
 :meth:`ListResource.list` accepts paging arguments.
 The following will return page 3 with page size of 25.
 
-.. code-block:: python
+.. code-block:: ruby
 
     require 'twilio-ruby'
 
@@ -57,7 +57,7 @@ The following will return page 3 with page size of 25.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @calls = client.calls.list(page=3, page_size=25)
+	@calls = @client.account.calls.list(:page=>3, :page_size=>25)
 
 
 Get an Individual Resource
@@ -76,6 +76,6 @@ Provide the :attr:`sid` of the resource you'd like to get.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @call = @client.calls.get("CA123")
+    @call = @client.account.calls.get("CA123")
     puts @call.to
 

--- a/docs/usage/caller-ids.rst
+++ b/docs/usage/caller-ids.rst
@@ -19,7 +19,7 @@ Validating a phone number is quick and easy.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @response = @client.caller_ids.create("+44 9876543212")
+    @response = @client.account.outgoing_caller_ids.create("+44 9876543212")
     puts @response.validation_code
 
 Twilio will call the provided number and wait for the validation code to be
@@ -40,6 +40,6 @@ Deleting a phone number is quick and easy.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @response = @client.caller_ids.list(phone_number="+15555555555")
+    @response = @client.account.outgoing_caller_ids.list(phone_number="+15555555555")
     @callerid = response[0]
     @callerid.delete()

--- a/docs/usage/conferences.rst
+++ b/docs/usage/conferences.rst
@@ -20,7 +20,7 @@ Listing Conferences
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @conferences = @client.conferences.list()
+    @conferences = @client.account.conferences.list()
 
     @conferences.each do |conference|
         puts conference.sid
@@ -43,7 +43,7 @@ will return a list of all in-progress conferences and print their friendly name.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @conferences = @client.conferences.list({:status => "in-progress"})
+    @conferences = @client.account.conferences.list({:status => "in-progress"})
     
     @conference.each do |conference|
         puts conference.friendly_name
@@ -64,7 +64,7 @@ Each :class:`Conference` has a :attr:`participants` instance which represents al
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @conference = @client.conferences.get("CF123")
+    @conference = @client.account.conferences.get("CF123")
 
     @conference.participants.list.each.do |paricipant|
         puts participant.sid
@@ -94,7 +94,7 @@ code kicks out the first participant and mutes the rest.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @participants = @client.conferences.get("CF123").participants.list()
+    @participants = @client.account.conferences.get("CF123").participants.list()
 
     if @participants.empty?
         return

--- a/docs/usage/messages.rst
+++ b/docs/usage/messages.rst
@@ -24,7 +24,7 @@ Send a text message in only a few lines of code.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @message = client.messages.create({:to => "+13216851234",
+    @message = @client.account.messages.create({:to => "+13216851234",
                                        :from => "+15555555555",
                                        :body => "Hello!"})
 
@@ -48,7 +48,7 @@ To send a picture, set :attr:`media_url` to the url of the picture you wish to s
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @message = client.messages.create({:to => "+15558676309",
+    @message = @client.account.messages.create({:to => "+15558676309",
                                        :from => "+15555555555",
                                        :body => "Jenny I need you!",
                                        :media_url => "http://twilio.com/heart.jpg"})
@@ -58,7 +58,7 @@ an array of urls.
 
 .. code-block:: ruby
 
-    @message = client.messages.create({:to => "+15558676309",
+    @message = @client.account.messages.create({:to => "+15558676309",
                                        :from => "+15555555555",
                                        :body => "Jenny I need you!",
                                        :media_url => [
@@ -80,7 +80,7 @@ Retrieving Sent Messages
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @client.messages.each do |message|
+    @client.account.messages.each do |message|
         puts message.body
 
 
@@ -101,8 +101,7 @@ The following will only show messages to "+5466758723" on January 1st, 2011.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @messages = client.messages.list({:to => "+5466758723",
-                                      :date_sent => date(2011,1,1)})
+    @messages = @client.account.messages.list({:to => "+5466758723", :date_sent => "2011-01-01"})
 
     @messages.each do |message|
         puts message.body

--- a/docs/usage/notifications.rst
+++ b/docs/usage/notifications.rst
@@ -24,7 +24,7 @@ current :class:`Notification` resources.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @client.notifications.list().each do |notification|:
+    @client.account.notifications.list().each do |notification|:
         puts notification.more_info
 
 You can filter transcriptions by :attr:`log` and :attr:`message_date`.
@@ -42,7 +42,7 @@ The :attr:`log` value is 0 for `ERROR` and 1 for `WARNING`.
 
     ERROR = 0
 
-    @client.notifications.list(log=ERROR).each do |notification|:
+    @client.account.notifications.list(log=ERROR).each do |notification|:
         puts notification.error_code
 
 .. note:: Due to the potentially voluminous amount of data in a notification,

--- a/docs/usage/phone-calls.rst
+++ b/docs/usage/phone-calls.rst
@@ -25,7 +25,7 @@ outputs valid `TwiML <http://www.twilio.com/docs/api/twiml/>`_.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @call = @client.calls.create({:to => "9991231234",
+    @call = @client.account.calls.create({:to => "9991231234",
                                   :from => "9991231234",
                                   :url => "http://foo.com/call.xml"})
     puts @call.length
@@ -48,7 +48,7 @@ you can use the client to retrieve that record.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
     sid = "CA12341234"
-    @call = @client.calls.get(sid)
+    @call = @client.account.calls.get(sid)
 
 
 Accessing Specific Call Resources
@@ -69,7 +69,7 @@ just like the :class:`Calls` resource itself.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
     sid = "CA12341234"
-    @call = @client.calls.get(sid)
+    @call = @client.account.calls.get(sid)
 
     puts @call.notifications.list()
     puts @call.recordings.list()
@@ -100,8 +100,6 @@ Modifying Live Calls
 The :class:`Call` resource makes it easy to find current live calls and
 redirect them as necessary
 
-.. code-block:: python
-
 .. code-block:: ruby
 
     require 'twilio-ruby'
@@ -111,7 +109,7 @@ redirect them as necessary
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @calls = @client.calls.list({:status => "in-progress")
+    @calls = @client.account.calls.list({:status => "in-progress"})
 
     @calls.each do |call|
         call.redirect_to("http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient")
@@ -129,7 +127,7 @@ Ending all live calls is also possible
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @calls = @client.calls.list({:status => "in-progress")
+    @calls = @client.account.calls.list({:status => "in-progress"})
 
     @calls.each do |call|
         call.hangup()
@@ -150,7 +148,7 @@ resource to update the record without having to use :meth:`get` first.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
     sid = "CA12341234"
-    @client.calls.get(sid).redirect_to("http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient")
+    @client.account.calls.get(sid).redirect_to("http://twimlets.com/holdmusic?Bucket=com.twilio.music.ambient")
 
 Hanging up the call also works.
 
@@ -164,5 +162,5 @@ Hanging up the call also works.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
     sid = "CA12341234"
-    @client.calls.get(sid).hangup()
+    @client.account.calls.get(sid).hangup()
 

--- a/docs/usage/phone-numbers.rst
+++ b/docs/usage/phone-numbers.rst
@@ -18,16 +18,16 @@ Finding numbers to buy couldn't be easier.
 We first search for a number in area code 530.
 Once we find one, we'll purchase it for our account.
 
-.. code-block:: python
+.. code-block:: ruby
 
-    from twilio.rest import TwilioRestClient
+    require 'twilio-ruby'
 
     # To find these visit https://www.twilio.com/user/account
-    ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXX"
-    AUTH_TOKEN = "YYYYYYYYYYYYYYYYYY"
+    account_sid = "ACXXXXXXXXXXXXXXXXX"
+    auth_token = "YYYYYYYYYYYYYYYYYY"
 
-    client = TwilioRestClient(ACCOUNT_SID, AUTH_TOKEN)
-    numbers = client.phone_numbers.search(area_code=530)
+    @client = Twilio::REST::Client.new account_sid, auth_token
+    numbers = @client.account.available_phone_numbers.list(:area_code=>"530")
 
     if numbers:
         numbers[0].purchase()
@@ -41,9 +41,9 @@ Toll Free Numbers
 By default, :meth:`PhoneNumbers.search` looks for local phone numbers. Add a
 :data:`type` : ``tollfree`` parameter to search toll-free numbers instead.
 
-.. code-block:: python
+.. code-block:: ruby
 
-    numbers = client.phone_numbers.search(type="tollfree")
+	numbers = @client.account.available_phone_numbers.list(:type=>"tollfree")
 
 
 Numbers Containing Words
@@ -52,15 +52,15 @@ Numbers Containing Words
 Phone number search also supports looking for words inside phone numbers.
 The following example will find any phone number with "FOO" in it.
 
-.. code-block:: python
+.. code-block:: ruby
 
-    numbers = client.phone_numbers.search(contains="FOO")
+	numbers = @client.account.available_phone_numbers.list(:contains=>"FOO")
 
 You can use the ''*'' wildcard to match any character. The following example finds any phone number that matches the pattern ''D*D''.
 
-.. code-block:: python
+.. code-block:: ruby
 
-    numbers = client.phone_numbers.search(contains="D*D")
+	numbers = @client.account.available_phone_numbers.list(:contains=>"D*D")
 
 
 International Numbers
@@ -70,9 +70,9 @@ By default, the client library will look for US numbers. Set the
 :data:`country` keyword to a country code of your choice to search for
 international numbers.
 
-.. code-block:: python
+.. code-block:: ruby
 
-    numbers = client.phone_numbers.search(country="FR")
+	numbers = @client.account.available_phone_numbers.list(:country=>"FR")
 
 
 :meth:`PhoneNumbers.search` method has plenty of other options to augment your search :
@@ -93,7 +93,7 @@ Buying a Number
 
 If you've found a phone number you want, you can purchase the number.
 
-.. code-block:: python
+.. code-block:: ruby
 
     from twilio.rest import TwilioRestClient
 
@@ -116,7 +116,7 @@ on the phone number object, with any of the parameters
 listed in the `IncomingPhoneNumbers Resource documentation
 <http://www.twilio.com/docs/api/rest/incoming-phone-numbers>`_
 
-.. code-block:: python
+.. code-block:: ruby
 
     from twilio.rest import TwilioRestClient
 
@@ -136,7 +136,7 @@ Changing Applications
 
 An :class:`Application` encapsulates all necessary URLs for use with phone numbers. Update an application on a phone number using :meth:`update`.
 
-.. code-block:: python
+.. code-block:: ruby
 
     from twilio.rest import TwilioRestClient
 

--- a/docs/usage/queues.rst
+++ b/docs/usage/queues.rst
@@ -22,7 +22,7 @@ Listing Queues
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @queues = client.queues.list()
+    @queues = @client.account.queues.list()
     
     @queues.each do |queue|
         puts queue.sid
@@ -44,7 +44,7 @@ represents all current calls in the queue.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @queue = @client.queues.get("QU123")
+    @queue = @client.account.queues.get("QU123")
 
     @queue.members.list().each do |member|
         print member.call_sid
@@ -75,7 +75,7 @@ first call in the queue.
     queue_sid = "QUAAAAAAAAAAAAA"
     call_sid = "CAXXXXXXXXXXXXXX"
     
-    @members = @client.queues.get(queue_sid).members
+    @members = @client.account.queues.get(queue_sid).members
 
     # Get the first call in the queue
     puts members.front.date_enqueued
@@ -106,7 +106,7 @@ default values are 'Front' and 'GET'
 
     queue_sid = "QUAAAAAAAAAAAAA"
 
-    @members = @client.queues.get(queue_sid).members
+    @members = @client.account.queues.get(queue_sid).members
 
     # Dequeue the first call in the queue
     puts @members.dequeue('http://www.twilio.com/welcome/call')

--- a/docs/usage/recordings.rst
+++ b/docs/usage/recordings.rst
@@ -35,7 +35,7 @@ for each :class:`Recording`.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @client.recordings.list().each do |recording|
+    @client.account.recordings.list().each do |recording|
         puts recording.duration
 
 You can filter recordings by CallSid by passing the Sid as :attr:`call`.
@@ -52,7 +52,7 @@ The following will only show recordings made before January 1, 2011.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @client.recordings.list(before=date(2011,1,1)).each do |recording|:
+    @client.account.recordings.list(before=date(2011,1,1)).each do |recording|:
         puts recording.duration
 
 
@@ -70,7 +70,7 @@ The :class:`Recordings` resource allows you to delete unnecessary recordings.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @client.recordings.get("RC123").delete()
+    @client.account.recordings.get("RC123").delete()
 
 
 Accessing Related Transcptions
@@ -89,7 +89,7 @@ with this recording.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @recording = @client.recordings.get("RC123")
+    @recording = @client.account.recordings.get("RC123")
 
     @recording.transcriptions.list().each do |transcription|
         puts transcription.transcription_text

--- a/docs/usage/sip.rst
+++ b/docs/usage/sip.rst
@@ -26,7 +26,7 @@ under sip.twilio.com.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @domain = @client.sip.domains.create(
+    @domain = @client.account.sip.domains.create(
         {:friendly_name => "The Office Domain",
          :voice_url => "http://example.com/voice",
          :domain_name => "dunder-mifflin-scranton.sip.twilio.com",}
@@ -50,7 +50,7 @@ to individual ip addresses. To do this, you'll first need to create an
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @ip_acl = @client.sip.ip_access_control_lists.create(
+    @ip_acl = @client.account.sip.ip_access_control_lists.create(
         {:friendly_name => "The Office IpAccessControlList",}
     )
     puts @ip_acl.sid
@@ -70,7 +70,7 @@ Now it's time to add an :class:`IpAddress` to your new :class:`IpAccessControlLi
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @ip_address = @client.sip.ip_access_control_lists.get(
+    @ip_address = @client.account.sip.ip_access_control_lists.get(
         "AL456",  # IpAccessControlList sid
     ).ip_addresses.create(
         {:friendly_name => "Dwights's Computer",
@@ -94,7 +94,7 @@ associate them. To do this, create an :class:`IpAccessControlListMapping`.
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @ip_acl_mapping = @client.sip.domains.get(
+    @ip_acl_mapping = @client.account.sip.domains.get(
         "SD456",  # SIP Domain sid
     ).ip_access_control_list_mappings.create(
         {:ip_access_control_list_sid => "AL789"})

--- a/docs/usage/transcriptions.rst
+++ b/docs/usage/transcriptions.rst
@@ -26,6 +26,6 @@ The following code will print out the length of each :class:`Transcription`.
     auth_token = "YYYYYYYYYYYYYYYYYY"
 
     @client = Twilio::REST::Client.new account_sid, auth_token
-    @client.transcriptions.list().each do |transcription|
+    @client.account.transcriptions.list().each do |transcription|
         puts transcription.duration
 

--- a/docs/usage/twiml.rst
+++ b/docs/usage/twiml.rst
@@ -13,7 +13,7 @@ These methods return the verbs they create to ease creation of nested TwiML.
 To finish, call the :meth:`toxml` method on the :class:`Response`,
 which returns raw TwiML.
 
-.. code-block:: python
+.. code-block:: ruby
 
     require 'twilio-ruby'
 
@@ -30,7 +30,7 @@ The verb methods (outlined in the :doc:`complete reference </api/twiml>`)
 take the body (only text) of the verb as the first argument.
 All attributes are keyword arguments.
 
-.. code-block:: python
+.. code-block:: ruby
 
     require 'twilio-ruby'
 
@@ -45,10 +45,9 @@ All attributes are keyword arguments.
         <Play loop="3">https://api.twilio.com/cowbell.mp3</Play>
     <Response>
 
-Python 2.6+ added the :const:`with` statement for context management.
-Using :const:`with`, the module can *almost* emulate Ruby blocks.
+Any example of nesting nouns in verbs
 
-.. code-block:: python
+.. code-block:: ruby
 
     require 'twilio-ruby'
 

--- a/docs/usage/validation.rst
+++ b/docs/usage/validation.rst
@@ -30,7 +30,7 @@ data as a dictionary and the url and X-Twilio-Signature as strings.
 The below example will print out a confirmation message if the request is
 actually from Twilio.
 
-.. code-block:: python
+.. code-block:: ruby
 
     require 'twilio-ruby'
 


### PR DESCRIPTION
changing resources access through the account rather than the client
ruby-ifying parameters and resource names
removing references to python
