### PR TITLE
Remove /SMS/Messages functionality

### DIFF
--- a/lib/twilio-ruby/rest/sms/messages.rb
+++ b/lib/twilio-ruby/rest/sms/messages.rb
@@ -2,9 +2,8 @@ module Twilio
   module REST
     class Messages < ListResource
       def initialize(path, client)
+        path.sub! '/SMS', ''
         super
-        # hard-code the json key since 'messages' doesn't exist in the response
-        @list_key = 'sms_messages'
       end
     end
 


### PR DESCRIPTION
Fixes #64. This pull routes all

``` ruby
@client.account.sms.messages
```

calls to be the same thing as 

``` ruby
@client.account.messages
```

It routes `sms.messages` to the `/Messages` Twilio endpoint. In essence, users of this helper library can no longer reach `/SMS/Messages`. This is okay, since `/Messages` provides the exact same functionality. This solution was chosen over fixing the name collision because it keeps the library's code much simpler.
