### PR TITLE
Fix code example for retrieving sent messages

### DIFF
--- a/docs/usage/messages.rst
+++ b/docs/usage/messages.rst
@@ -80,7 +80,7 @@ Retrieving Sent Messages
 
     @client = Twilio::REST::Client.new account_sid, auth_token
 
-    @client.account.messages.each do |message|
+    @client.account.messages.list.each do |message|
         puts message.body
 
 


### PR DESCRIPTION
# each is not a method on messages. It needs to be .list.each.

As discussed here: https://github.com/twilio/twilio-ruby/issues/81
