### PR TITLE
Alias #to_xml to #text for Twilio::TwiML::Response

### DIFF
--- a/lib/twilio-ruby/twiml/response.rb
+++ b/lib/twilio-ruby/twiml/response.rb
@@ -3,6 +3,7 @@ module Twilio
     class Response
 
       attr_reader :text
+      alias_method :to_xml , :text
 
       def initialize(&block)
         xml = Builder::XmlMarkup.new


### PR DESCRIPTION
`#to_xml` is the more common way to get an XML serialized object, and some libraries/frameworks (e.g. Grape) expect a `#to_xml` method to exist.

Aliases `#to_xml` to `#text`
