### PR TITLE
Use lower camel case for TwiML verb arguments

### DIFF
--- a/docs/usage/twiml.rst
+++ b/docs/usage/twiml.rst
@@ -53,7 +53,7 @@ Any example of nesting nouns in verbs
 
     Twilio::TwiML::Response.new do |r|
         r.Say "hello"
-        r.Gather :finish_on_key => 4 do |g|
+        r.Gather :finishOnKey => 4 do |g|
             g.Say "world"
         end
     end.text


### PR DESCRIPTION
The existing example will not camel case the existing finish_on_key argument to return finishOnKey as expected.
