### PR TITLE
Pins JWT to ~> 1.0.0 and fixes tests.

### DIFF
--- a/spec/util/capability_spec.rb
+++ b/spec/util/capability_spec.rb
@@ -11,7 +11,7 @@ describe Twilio::Util::Capability do
 
   it 'should return a valid jwt when #generate is called' do
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     decoded['scope'].should_not be_nil
     decoded['iss'].should_not be_nil
     decoded['exp'].should_not be_nil
@@ -19,14 +19,14 @@ describe Twilio::Util::Capability do
 
   it 'should properly set the iss key in the payload' do
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     decoded['iss'].should == 'myAccountSid'
   end
 
   it 'should properly set the exp key based on the default hour ttl' do
     seconds = Time.now.to_i
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     decoded['exp'].should == seconds + 3600
   end
 
@@ -34,14 +34,14 @@ describe Twilio::Util::Capability do
     ttl = rand 10000
     seconds = Time.now.to_i
     token = @capability.generate ttl
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     decoded['exp'].should == seconds + ttl
   end
 
   it 'should generate a proper incoming client scope string' do
     @capability.allow_client_incoming 'andrew'
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     queries(decoded['scope']).should == [['incoming', {'clientName' => 'andrew'}]]
   end
 
@@ -49,7 +49,7 @@ describe Twilio::Util::Capability do
     @capability.allow_client_incoming 'andrew'
     @capability.allow_client_incoming 'bridget'
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     queries(decoded['scope']).should == [
       ['incoming', {'clientName' => 'andrew'}],
       ['incoming', {'clientName' => 'bridget'}]
@@ -59,7 +59,7 @@ describe Twilio::Util::Capability do
   it 'should generate a proper outgoing client scope string' do
     @capability.allow_client_outgoing 'myAppSid'
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     queries(decoded['scope']).should == [['outgoing', {'appSid' => 'myAppSid'}]]
   end
 
@@ -70,7 +70,7 @@ describe Twilio::Util::Capability do
     params_hash = {'appSid' => 'myAppSid', 'appParams' => app_params}
     @capability.instance_eval {url_encode(params_hash)}
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     queries(decoded['scope']).should == [['outgoing', params_hash]]
   end
 
@@ -79,7 +79,7 @@ describe Twilio::Util::Capability do
     @capability.allow_client_incoming 'andrew'
     @capability.allow_client_outgoing 'myAppSid'
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     queries(decoded['scope']).should == [
       ['incoming', {'clientName' => 'andrew'}],
       ['outgoing', {'clientName' => 'andrew', 'appSid' => 'myAppSid'}]
@@ -91,7 +91,7 @@ describe Twilio::Util::Capability do
     @capability.allow_client_outgoing 'myAppSid'
     @capability.allow_client_incoming 'andrew'
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     queries(decoded['scope']).should == [["incoming", {"clientName"=>"andrew"}], ["outgoing", {"clientName"=>"andrew", "appSid"=>"myAppSid"}]]
   end
 
@@ -104,7 +104,7 @@ describe Twilio::Util::Capability do
     params_hash = {'appSid' => 'myAppSid', 'appParams' => app_params, 'clientName' => 'andrew'}
     @capability.instance_eval {url_encode(params_hash)}
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     scopes = queries(decoded['scope'])
     scopes.shift.should == ["incoming", {"clientName"=>"andrew"}]
     scope = scopes.shift
@@ -124,7 +124,7 @@ describe Twilio::Util::Capability do
     params_hash = {'appSid' => 'myAppSid', 'appParams' => app_params, 'clientName' => 'andrew'}
     @capability.instance_eval {url_encode(params_hash)}
     token = @capability.generate
-    decoded = JWT.decode token, 'myAuthToken'
+    decoded, header = JWT.decode token, 'myAuthToken'
     scopes = queries(decoded['scope'])
     scopes.shift.should == ["incoming", {"clientName"=>"andrew"}]
     scope = scopes.shift

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('multi_json', '>= 1.3.0')
   s.add_dependency('builder', '>= 2.1.2')
-  s.add_dependency('jwt', '>= 0.1.2')
+  s.add_dependency('jwt', '~> 1.0.0')
   s.add_dependency('jruby-openssl') if RUBY_PLATFORM == 'java'
   # Workaround for RBX <= 2.2.1, should be fixed in next version
   s.add_dependency('rubysl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'


### PR DESCRIPTION
JWT started to return both the payload and a header when decoding a token since
[this pull request](https://github.com/progrium/ruby-jwt/pull/35). This has
since become part of the version 1.0 release, so this gem might as well
encourage usage of 1.0 and get fixed tests for that.
