### PR TITLE
Updates rspec to v3. Removes Gemfile gems from gemspec.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 group :test do
   gem 'rake', '~> 10.1'
-  gem 'rspec', '~> 2.6'
+  gem 'rspec', '~> 3.0'
   gem 'fakeweb', '~> 1.3'
   gem 'rack', '~> 1.3'
 end

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -28,8 +28,5 @@ Gem::Specification.new do |spec|
   # Workaround for RBX <= 2.2.1, should be fixed in next version
   spec.add_dependency('rubysl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 
-  spec.add_development_dependency 'rspec',   '~> 2.14'
-  spec.add_development_dependency 'fakeweb', '~> 1.3.0'
-  spec.add_development_dependency 'rack',    '~> 1.3.0'
   spec.add_development_dependency 'bundler', '~> 1.5'
 end


### PR DESCRIPTION
The rspec syntax for the test was updated recently, but rspec itself wasn't bumped, so old installs would fail the tests.

Also, rspec, fakeweb and rack were all declared in both the Gemfile test group and as development dependencies in the gemspec. Whilst I'd rather have them as development dependencies, I noticed a [commit](https://github.com/twilio/twilio-ruby/commit/908713fe50e1700e4672dd5e3d797d9b7a6d8b1c) from @karlfreeman that moved them to the Gemfile, so I will stick with this for the project. I have removed them again from the gemspec for consistency.
