### PR TITLE
Bump ruby version in gemspec to 1.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ implementations:
 - Ruby 2.1.0
 - Ruby 2.0.0
 - Ruby 1.9.3
-- Ruby 1.8.7
 - [JRuby][jruby]
 - [Rubinius][rubinius]
 

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 1.9.3'
   spec.extra_rdoc_files = ['README.md', 'LICENSE.md']
   spec.rdoc_options = ['--line-numbers', '--inline-source', '--title', 'twilio-ruby', '--main', 'README.md']
 


### PR DESCRIPTION
When installing twilio-ruby gem in 1.8.7 it's downloading the latest version (3.13.0) even though it's not compatible with ruby 1.8.7.
