### PR TITLE
sets ssl_version to TLSv1

### DIFF
--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -65,6 +65,7 @@ module Twilio
         host: 'api.twilio.com',
         port: 443,
         use_ssl: true,
+        ssl_version: :TLSv1,
         ssl_verify_peer: true,
         ssl_ca_file: File.dirname(__FILE__) + '/../../../conf/cacert.pem',
         timeout: 30,
@@ -221,6 +222,7 @@ module Twilio
       # This is a private method documented for completeness.
       def set_up_ssl # :doc:
         @connection.use_ssl = @config[:use_ssl]
+        @connection.ssl_version = @config[:ssl_version]
         if @config[:ssl_verify_peer]
           @connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
           @connection.ca_file = @config[:ssl_ca_file]


### PR DESCRIPTION
Twilio gem doesn't work with api.twilio.com after SSLv3 was disabled.

This enforces SSL version to TLSv1
