### PR TITLE
Replace nil signature with empty string.

### DIFF
--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -29,7 +29,7 @@ module Rack
       request = Rack::Request.new(env)
       original_url = request.url
       params = request.post? ? request.POST : {}
-      signature = env['HTTP_X_TWILIO_SIGNATURE']
+      signature = env['HTTP_X_TWILIO_SIGNATURE'] || ""
       if validator.validate(original_url, params, signature)
         @app.call(env)
       else


### PR DESCRIPTION
Hello,

I found a bug where Rack will return an HTTP 500 error when the X-Twilio-Signature header is nil or missing instead of an HTTP 403. The following exception was returned.

```
NoMethodError: undefined method `bytesize' for nil:NilClass
        /Users/ryan/.gem/ruby/2.1.5/gems/twilio-ruby-3.14.1/lib/twilio-ruby/util/request_validator.rb:27:in `secure_compare'
        /Users/ryan/.gem/ruby/2.1.5/gems/twilio-ruby-3.14.1/lib/twilio-ruby/util/request_validator.rb:12:in `validate'
        /Users/ryan/.gem/ruby/2.1.5/gems/twilio-ruby-3.14.1/lib/rack/twilio_webhook_authentication.rb:33:in `call'
        /Users/ryan/.gem/ruby/2.1.5/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
        /Users/ryan/.gem/ruby/2.1.5/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
        /Users/ryan/.gem/ruby/2.1.5/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
        /Users/ryan/.gem/ruby/2.1.5/gems/rack-1.5.2/lib/rack/commonlogger.rb:33:in `call'
```

I have included a pull request that replaces the signature with an empty string if `env['HTTP_X_TWILIO_SIGNATURE']` is nil. Thank you.
