### PR TITLE
Compute auth_token dynamically based on AccoundSid from request params

### DIFF
--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -25,10 +25,11 @@ module Rack
 
     def call(env)
       return @app.call(env) unless env["PATH_INFO"].match(@path_regex)
-      validator = Twilio::Util::RequestValidator.new(@auth_token)
       request = Rack::Request.new(env)
       original_url = request.url
       params = request.post? ? request.POST : {}
+      @auth_token ||= getAuthToken(params['AccountSid'])
+      validator = Twilio::Util::RequestValidator.new(@auth_token)
       signature = env['HTTP_X_TWILIO_SIGNATURE'] || ""
       if validator.validate(original_url, params, signature)
         @app.call(env)
@@ -39,6 +40,10 @@ module Rack
           ["Twilio Request Validation Failed."]
         ]
       end
+    end
+
+    def getAuthToken account_sid
+      ''
     end
   end
 end

--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -29,8 +29,8 @@ module Rack
       request = Rack::Request.new(env)
       original_url = request.url
       params = request.post? ? request.POST : {}
-      @auth_token ||=  get_auth_token(params['AccountSid'])
-      validator = Twilio::Util::RequestValidator.new(@auth_token)
+      auth_token = @auth_token || get_auth_token(params['AccountSid'])
+      validator = Twilio::Util::RequestValidator.new(auth_token)
       signature = env['HTTP_X_TWILIO_SIGNATURE'] || ""
       if validator.validate(original_url, params, signature)
         @app.call(env)

--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -17,10 +17,10 @@ module Rack
   # doesn't validate then the middleware responds immediately with a 403 status.
 
   class TwilioWebhookAuthentication
-    def initialize(app, auth_token, *paths, &block)
+    def initialize(app, auth_token, *paths, &auth_token_lookup)
       @app = app
       @auth_token = auth_token
-      define_singleton_method(:getAuthToken, block) if block_given?
+      define_singleton_method(:get_auth_token, auth_token_lookup) if block_given?
       @path_regex = Regexp.union(paths)
     end
 
@@ -29,7 +29,7 @@ module Rack
       request = Rack::Request.new(env)
       original_url = request.url
       params = request.post? ? request.POST : {}
-      @auth_token ||=  getAuthToken(params['AccountSid'])
+      @auth_token ||=  get_auth_token(params['AccountSid'])
       validator = Twilio::Util::RequestValidator.new(@auth_token)
       signature = env['HTTP_X_TWILIO_SIGNATURE'] || ""
       if validator.validate(original_url, params, signature)

--- a/spec/rack/twilio_webhook_authentication_spec.rb
+++ b/spec/rack/twilio_webhook_authentication_spec.rb
@@ -28,10 +28,15 @@ describe Rack::TwilioWebhookAuthentication do
 
   describe 'calling against one path with dynamic auth token' do
     it 'should allow a request through if it validates' do
-      @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/)
+      auth_token = 'qwerty'
+      account_sid = 12345
+      expect_any_instance_of(Rack::Request).to receive(:post?).and_return(true)
+      expect_any_instance_of(Rack::Request).to receive(:POST).and_return({'AccountSid' => account_sid})
+      @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/) { |asid| auth_token}
       expect_any_instance_of(Twilio::Util::RequestValidator).to receive(:validate).and_return(true)
       request = Rack::MockRequest.env_for('/voice')
       status, headers, body = @middleware.call(request)
+      expect(@middleware.instance_variable_get(:@auth_token)).to eq(auth_token)
       expect(status).to be(200)
     end
   end

--- a/spec/rack/twilio_webhook_authentication_spec.rb
+++ b/spec/rack/twilio_webhook_authentication_spec.rb
@@ -33,10 +33,11 @@ describe Rack::TwilioWebhookAuthentication do
       expect_any_instance_of(Rack::Request).to receive(:post?).and_return(true)
       expect_any_instance_of(Rack::Request).to receive(:POST).and_return({'AccountSid' => account_sid})
       @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/) { |asid| auth_token}
-      expect_any_instance_of(Twilio::Util::RequestValidator).to receive(:validate).and_return(true)
+      request_validator = double('RequestValidator')
+      expect(Twilio::Util::RequestValidator).to receive(:new).with(auth_token).and_return(request_validator)
+      expect(request_validator).to receive(:validate).and_return(true)
       request = Rack::MockRequest.env_for('/voice')
       status, headers, body = @middleware.call(request)
-      expect(@middleware.instance_variable_get(:@auth_token)).to eq(auth_token)
       expect(status).to be(200)
     end
   end

--- a/spec/rack/twilio_webhook_authentication_spec.rb
+++ b/spec/rack/twilio_webhook_authentication_spec.rb
@@ -18,6 +18,22 @@ describe Rack::TwilioWebhookAuthentication do
         Rack::TwilioWebhookAuthentication.new(@app, 'ABC', /\/voice/, /\/sms/)
       }.not_to raise_error
     end
+
+    it 'should initialize with an app, dynamic token and paths' do
+      expect {
+        Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/, /\/sms/)
+      }.not_to raise_error
+    end
+  end
+
+  describe 'calling against one path with dynamic auth token' do
+    it 'should allow a request through if it validates' do
+      @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/)
+      expect_any_instance_of(Twilio::Util::RequestValidator).to receive(:validate).and_return(true)
+      request = Rack::MockRequest.env_for('/voice')
+      status, headers, body = @middleware.call(request)
+      expect(status).to be(200)
+    end
   end
 
   describe 'calling against one path' do


### PR DESCRIPTION
Hi,

We are using Twilio with its sub-accounts feature extensively. Our business use-case is such that the Twilio web-hook request comes from the sub-account's TwiML app. Existing Rack while being a sweet convenience, doesn't have the feature to dynamically fetch the Twilio's Auth-Token based on the `AccountSid` of the sub-account. Because this AccountSid is sent with the request params from Twilio, it makes sense to fetch the auth-token for that sub-account from our end.

This PR is a tested patch enhancing the Rack to get auth-token dynamically. How can it be done? Simply pass nil instead of the auth_token argument, making the rack to call the `getAuthToken(account_sid)` method. The end-user can over-ride this method to suit their implementation of fetching the `AuthToken` based on `account_sid`

In our case for instance, we create `config/initializers/twilio.rb` in our rails project with code something like below:
```
module Rack
  class TwilioWebhookAuthentication
    def getAuthToken account_sid
      return '' if account_sid.nil?
      user = User.find_by_twilio_account_sid(account_sid)
      user.present? ? user.tauthtoken : ''
    end
  end
end

```

Hope you like it and others find it useful :)