### PR TITLE
Make it clear that license is MIT

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
 Copyright (c) 2010-2014 Andrew Benton.
 
+The MIT License (MIT)
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
Considering use of this gem in a project I'm starting.  License wasn't labeled as MIT.  Ended up visually comparing against a known copy of MIT to be sure.