### PR TITLE
Uses configuration object instead of defaults hash for REST clients

### DIFF
--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -10,6 +10,7 @@ require 'jwt'
 
 require 'twilio-ruby/version' unless defined?(Twilio::VERSION)
 require 'twilio-ruby/util'
+require 'twilio-ruby/util/client_config'
 require 'twilio-ruby/util/configuration'
 require 'twilio-ruby/util/request_validator'
 require 'twilio-ruby/util/capability'

--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -12,6 +12,8 @@ module Twilio
                         " #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL})"
       }
 
+      ##
+      # Override the default host for a REST Client (api.twilio.com)
       def self.host(host=nil)
         return @host unless host
         @host = host
@@ -54,13 +56,6 @@ module Twilio
       end
 
       protected
-
-      ##
-      # Get the default config values.
-      def get_defaults
-        # To be overridden
-        DEFAULTS
-      end
 
       ##
       # Builds up full request path

--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -53,6 +53,8 @@ module Twilio
 
       attr_reader :account, :accounts
 
+      host 'api.twilio.com'
+
       ##
       # Instantiate a new HTTP client to talk to Twilio. The parameters
       # +account_sid+ and +auth_token+ are required, unless you have configured

--- a/lib/twilio-ruby/rest/lookups_client.rb
+++ b/lib/twilio-ruby/rest/lookups_client.rb
@@ -4,21 +4,9 @@ module Twilio
     class LookupsClient < BaseClient
       API_VERSION = 'v1'
 
-      DEFAULTS = {
-          host: 'lookups.twilio.com',
-          port: 443,
-          use_ssl: true,
-          ssl_verify_peer: true,
-          ssl_ca_file: File.dirname(__FILE__) + '/../../../conf/cacert.pem',
-          timeout: 30,
-          proxy_addr: nil,
-          proxy_port: nil,
-          proxy_user: nil,
-          proxy_pass: nil,
-          retry_limit: 1
-      }
-
       attr_reader :phone_numbers
+
+      host 'lookups.twilio.com'
 
       ##
       # Instantiate a new HTTP Lookups client to talk to Twilio. The parameters

--- a/lib/twilio-ruby/rest/lookups_client.rb
+++ b/lib/twilio-ruby/rest/lookups_client.rb
@@ -81,12 +81,6 @@ module Twilio
       protected
 
       ##
-      # Get the default config values.
-      def get_defaults
-        DEFAULTS
-      end
-
-      ##
       # Set up +phone_numbers+ attribute.
       def set_up_subresources # :doc:
         @phone_numbers = Twilio::REST::Lookups::PhoneNumbers.new "/#{API_VERSION}/PhoneNumbers", self

--- a/lib/twilio-ruby/rest/task_router_client.rb
+++ b/lib/twilio-ruby/rest/task_router_client.rb
@@ -4,21 +4,9 @@ module Twilio
     class TaskRouterClient < BaseClient
       API_VERSION = 'v1'
 
-      DEFAULTS = {
-          host: 'taskrouter.twilio.com',
-          port: 443,
-          use_ssl: true,
-          ssl_verify_peer: true,
-          ssl_ca_file: File.dirname(__FILE__) + '/../../../conf/cacert.pem',
-          timeout: 30,
-          proxy_addr: nil,
-          proxy_port: nil,
-          proxy_user: nil,
-          proxy_pass: nil,
-          retry_limit: 1
-      }
-
       attr_reader :workspace, :workspace_sid, :workspaces
+
+      host 'taskrouter.twilio.com'
 
       ##
       # Instantiate a new HTTP TaskRouter client to talk to Twilio. The parameters

--- a/lib/twilio-ruby/rest/task_router_client.rb
+++ b/lib/twilio-ruby/rest/task_router_client.rb
@@ -166,12 +166,6 @@ module Twilio
       protected
 
       ##
-      # Get the default config values.
-      def get_defaults
-        DEFAULTS
-      end
-
-      ##
       # Set up +workspace+ and +workspaces+ attributes.
       def set_up_subresources # :doc:
         @workspaces = Twilio::REST::TaskRouter::Workspaces.new "/#{API_VERSION}/Workspaces", self

--- a/lib/twilio-ruby/util/client_config.rb
+++ b/lib/twilio-ruby/util/client_config.rb
@@ -1,0 +1,29 @@
+module Twilio
+  module Util
+    class ClientConfig
+      DEFAULTS = {
+          host: 'api.twilio.com',
+          port: 443,
+          use_ssl: true,
+          ssl_verify_peer: true,
+          ssl_ca_file: File.dirname(__FILE__) + '/../../../conf/cacert.pem',
+          timeout: 30,
+          proxy_addr: nil,
+          proxy_port: nil,
+          proxy_user: nil,
+          proxy_pass: nil,
+          retry_limit: 1
+      }
+
+      DEFAULTS.each_key do |attribute|
+        attr_accessor attribute
+      end
+
+      def initialize(opts={})
+        DEFAULTS.each do |attribute, value|
+          send("#{attribute}=".to_sym, opts.fetch(attribute, value))
+        end
+      end
+    end
+  end
+end

--- a/spec/util/client_config_spec.rb
+++ b/spec/util/client_config_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Twilio::Util::ClientConfig do
+  Twilio::Util::ClientConfig::DEFAULTS.each do |attribute, value|
+    it "sets an attribute with a default value" do
+      config = Twilio::Util::ClientConfig.new
+      expect(config.send(attribute)).to eq(value)
+    end
+
+    it "can update the value for the attribute" do
+      config = Twilio::Util::ClientConfig.new
+      config.send("#{attribute}=", "blah")
+      expect(config.send(attribute)).to eq("blah")
+    end
+
+    it "can set the value from a hash in the initializer" do
+      config = Twilio::Util::ClientConfig.new(attribute => 'blah')
+      expect(config.send(attribute)).to eq("blah")
+    end
+  end
+end

--- a/spec/util/configuration_spec.rb
+++ b/spec/util/configuration_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Twilio::Util::Configuration do
   it 'should have an account sid attribute' do
     config = Twilio::Util::Configuration.new


### PR DESCRIPTION
Rather than repeating a mostly similar `DEFAULTS` hash across the REST Clients this pull request introduces a `ClientConfig` object that encapsulates the defaults and allows them to be overridden when they need to be.

Since only one default is overridden at the moment, the `host`, this also includes a class method on the `BaseClient` that can be called on the subclasses to set the relevant host.