### PR TITLE
Stops rescuing Exception, rescues StandardError instead.

### DIFF
--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -110,7 +110,7 @@ module Twilio
           if response.kind_of? Net::HTTPServerError
             raise Twilio::REST::ServerError
           end
-        rescue Exception
+        rescue
           raise if request.class == Net::HTTP::Post
           if retries_left > 0 then retries_left -= 1; retry else raise end
         end


### PR DESCRIPTION
[You shouldn't rescue `Exception` in Ruby](http://daniel.fone.net.nz/blog/2013/05/28/why-you-should-never-rescue-exception-in-ruby/). It will rescue `NoMemoryError` and `Interrupt` and others you don't really want to rescue from in this case. `StandardError`, which is the default when just using `rescue`, is better, but ideally this would rescue specific errors that we want to rescue from. Perhaps looking at [Faraday's list of errors](https://github.com/lostisland/faraday/blob/1d71fcab65d0baa0e8abeb26d819856f7d29356d/lib/faraday/adapter/net_http.rb#L12-L24) or [this suggestion from Tammer Saleh](http://tammersaleh.com/posts/rescuing-net-http-exceptions/) would be better. The least we can do is stop rescuing `Exception` though.