### PR TITLE
Define object in case of Net::HTTPBadRequest

### DIFF
--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -116,7 +116,10 @@ module Twilio
         end
         if response.body and !response.body.empty?
           object = MultiJson.load response.body
+        elsif response.kind_of? Net::HTTPBadRequest
+          object = { message: 'Bad request', code: 400 }
         end
+
         if response.kind_of? Net::HTTPClientError
           raise Twilio::REST::RequestError.new object['message'], object['code']
         end


### PR DESCRIPTION
First, some background.

I have a Rails app which has a `config/initializers/twilio.rb`:

```ruby
require 'twilio-ruby'

Twilio.configure do |config|
  config.account_sid = "[sid]"
  config.auth_token = "[auth token]"
end
```

I can successfully use this code to send an SMS:

```ruby
sms_number = "[redacted]"
dialing_code = "+61"
phone_number = "[redacted]"

client = Twilio::REST::Client.new
message = client.account.messages.create({
  :from => "#{sms_number}",
  :to => "+#{dialing_code} #{phone_number}",
  :body => "Your verification code for Bike Exchange is #{verification_code}",
})
```

That works nicely.

Today, I wanted to validate phone numbers and I saw that Twilio now has a lookups API for that. There's no documentation in the README for this gem wrt to lookups, so I had to piece together how to use this. I guessed this (running in a `rails console`):

```ruby
lookups = Twilio::REST::LookupsClient.new
lookups.get("+61[my phone number, but redacted]")
```

When this request is made, Twilio returns a "400 Bad Request" error. Unfortunately for the Twilio gem, the response body is empty, and so `object` isn't set at all. `Net::HTTPBadRequest` is indeed a kind of `Net::HTTPClientError`, which you can check with:

```ruby
 Net::HTTPBadRequest < Net::HTTPClientError
```

Alternatively, you could look through the docs for a couple of minutes. Back on track: because `object` isn't set, the code inside this final `if` isn't able to `raise` the exception because `object` is nil. Instead what happens, is this:

```ruby
[2] pry(main)> lookups.get("+[my redacted phone number]")
NoMethodError: undefined method `[]' for nil:NilClass
from /Users/ryanbigg/.gem/ruby/2.2.2/gems/twilio-ruby-4.0.0/lib/twilio-ruby/rest/base_client.rb:121:in `connect_and_send'
```

So either:

1. I am using this library wrong and it's a PEBKAC, so there should be documentation written in the README informing people how to use it _properly_; or
2. I am using it correctly and it's the library's fault some how.

Please advise.
