### PR TITLE
Fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ implementations:
 - Ruby 1.9.3
 - [JRuby][jruby]
 - [Rubinius][rubinius]
-- 
 
 ## Getting help
 


### PR DESCRIPTION
A small markdown fix to prevent the last item in the list `Supported Ruby Versions` from becoming more than just an item. :ok_woman: