### PR TITLE
Include error message and code when raising ServerError

### DIFF
--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -108,7 +108,7 @@ module Twilio
           response = @connection.request request
           @last_response = response
           if response.kind_of? Net::HTTPServerError
-            raise Twilio::REST::ServerError
+            raise Twilio::REST::ServerError.new response.message, response.code
           end
         rescue
           raise if request.class == Net::HTTP::Post

--- a/lib/twilio-ruby/rest/errors.rb
+++ b/lib/twilio-ruby/rest/errors.rb
@@ -1,6 +1,13 @@
 module Twilio
   module REST
-    class ServerError < StandardError; end
+    class ServerError < StandardError
+      attr_reader :code
+
+      def initialize(message, code)
+        super "#{code} - #{message}"
+        @code = code
+      end
+    end
 
     class RequestError < StandardError
       attr_reader :code


### PR DESCRIPTION
Add the message and code from a failing request to the exception message, to
aid in debugging.
