### PR TITLE
Add messaging attribute to pricing_client. 

### DIFF
--- a/lib/twilio-ruby/rest/pricing_client.rb
+++ b/lib/twilio-ruby/rest/pricing_client.rb
@@ -8,7 +8,7 @@ module Twilio
 
       API_VERSION = 'v1'
 
-      attr_reader :voice, :phone_numbers
+      attr_reader :voice, :phone_numbers, :messaging
 
       host 'pricing.twilio.com'
 

--- a/spec/rest/pricing_client_spec.rb
+++ b/spec/rest/pricing_client_spec.rb
@@ -42,4 +42,19 @@ describe Twilio::REST::PricingClient do
       '/v1/PhoneNumbers/Countries'
     )
   end
+
+  it 'should set up a messaging resources object' do
+    expect(@client).to respond_to(:messaging)
+    expect(@client.messaging.instance_variable_get('@path')).to eq(
+      '/v1/Messaging'
+    )
+  end
+
+  it 'should set up the country list resource on messaging' do
+    messaging = @client.messaging
+    expect(messaging).to respond_to(:countries)
+    expect(messaging.countries.instance_variable_get('@path')).to eq(
+      '/v1/Messaging/Countries'
+    )
+  end
 end


### PR DESCRIPTION
Fixes messaging pricing being broken. We had defined the subresource but forgot to make it accessible.