### PR TITLE
Load instance resource on respond_to? calls

### DIFF
--- a/lib/twilio-ruby/rest/instance_resource.rb
+++ b/lib/twilio-ruby/rest/instance_resource.rb
@@ -70,6 +70,15 @@ module Twilio
         self.send method, *args
       end
 
+      ##
+      # Lazily load attributes of the instance resource by waiting to fetch it
+      # until an attempt is made to access an unknown attribute.
+      def respond_to?(method, include_private = false)
+        return super if @updated
+        set_up_properties_from(@client.get(@path))
+        super
+      end
+
       protected
 
       def set_up_properties_from(hash)

--- a/spec/rest/instance_resource_spec.rb
+++ b/spec/rest/instance_resource_spec.rb
@@ -12,4 +12,20 @@ describe Twilio::REST::InstanceResource do
     resource = Twilio::REST::InstanceResource.new('uri', 'client', params)
     expect(resource.some_key).to eq('someValue')
   end
+
+  context 'lazy loading' do
+    before do
+      client = double
+      expect(client).to receive(:get).with('uri').and_return({ 'SomeKey' => 'someValue' })
+      @resource = Twilio::REST::InstanceResource.new('uri', client)
+    end
+
+    it 'should load when a missing method is called' do
+      expect(@resource.some_key).to eq('someValue')
+    end
+
+    it 'should load when #respond_to? is called' do
+      expect(@resource.respond_to?(:some_key)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Fixes a bug caused by Rails 4's #try using respond_to?, which
causes it to always return nil when used on an instance resource
that hasn't been loaded yet. Can be worked around by using
try! instead, but that's annoying.

I'm deliberately not implementing `respond_to_missing?` because #method has already decided at the point where it calls `respond_to_missing?` that `method_missing` needs to be invoked because the method doesn't exist, and doesn't change its mind after the method is created. That's considerably less trivial to fix, and beyond the scope of what I need.
