### PR TITLE
Loading Reservations under a Worker by default in TaskRouter JS SDK

### DIFF
--- a/lib/twilio-ruby/task_router/capability.rb
+++ b/lib/twilio-ruby/task_router/capability.rb
@@ -136,8 +136,11 @@ module Twilio
           @activityUrl = @baseUrl + "/Activities"
           allow(@activityUrl, "GET")
 
-          @reservationsUrl = @baseUrl + "/Tasks/**"
-          allow(@reservationsUrl, "GET")
+          @tasksUrl = @baseUrl + "/Tasks/**"
+          allow(@tasksUrl, "GET")
+
+          @workerReservationsUrl = @resourceUrl + "/Reservations/**"
+          allow(@workerReservationsUrl, "GET")
 
         elsif(@channel_id[0..1] == 'WQ')
           @resourceUrl = @baseUrl + "/TaskQueues/" + @channel_id
@@ -171,11 +174,13 @@ module Twilio
 
       def initialize(account_sid, auth_token, workspace_sid, worker_sid)
         super(account_sid, auth_token, workspace_sid, worker_sid)
-        @reservationsUrl = @baseUrl + "/Tasks/**"
+        @tasksUrl = @baseUrl + "/Tasks/**"
         @activityUrl = @baseUrl + "/Activities"
+        @workerReservationsUrl = @resourceUrl + "/Reservations/**"
 
         allow(@activityUrl, "GET")
-        allow(@reservationsUrl, "GET")
+        allow(@tasksUrl, "GET")
+        allow(@workerReservationsUrl, "GET")
       end
 
       def allow_activity_updates
@@ -183,7 +188,8 @@ module Twilio
       end
 
       def allow_reservation_updates
-        allow(@reservationsUrl, "POST", nil, nil)
+        allow(@tasksUrl, "POST", nil, nil)
+        allow(@workerReservationsUrl, "POST", nil, nil)
       end
 
       protected

--- a/spec/task_router_deprecated_spec.rb
+++ b/spec/task_router_deprecated_spec.rb
@@ -42,7 +42,7 @@ describe Twilio::TaskRouter::Capability do
     it 'should allow websocket operations and fetching the workspace by default' do
       token = @capability.generate_token
       decoded, header = JWT.decode token, 'foobar'
-      expect(decoded['policies'].size).to eq(5)
+      expect(decoded['policies'].size).to eq(6)
 
       activites_fetch_policy = {
           'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Activities',
@@ -53,14 +53,23 @@ describe Twilio::TaskRouter::Capability do
       }
       expect(decoded['policies'][0]).to eq(activites_fetch_policy)
 
-      reservation_fetch_policy = {
+      task_fetch_policy = {
           'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**',
           'method' => 'GET',
           'query_filter' => {},
           'post_filter' => {},
           'allow' => true
       }
-      expect(decoded['policies'][1]).to eq(reservation_fetch_policy)
+      expect(decoded['policies'][1]).to eq(task_fetch_policy)
+
+      worker_reservation_fetch_policy = {
+          'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**',
+          'method' => 'GET',
+          'query_filter' => {},
+          'post_filter' => {},
+          'allow' => true
+      }
+      expect(decoded['policies'][2]).to eq(worker_reservation_fetch_policy)
 
       get_policy = {
         "url" => 'https://event-bridge.twilio.com/v1/wschannels/AC123/WK789',
@@ -69,7 +78,7 @@ describe Twilio::TaskRouter::Capability do
         "post_filter" => {},
         "allow" => true
       }
-      expect(decoded['policies'][2]).to eq(get_policy)
+      expect(decoded['policies'][3]).to eq(get_policy)
       post_policy = {
         "url" => 'https://event-bridge.twilio.com/v1/wschannels/AC123/WK789',
         "method" => 'POST',
@@ -77,7 +86,7 @@ describe Twilio::TaskRouter::Capability do
         "post_filter" => {},
         "allow" => true
       }
-      expect(decoded['policies'][3]).to eq(post_policy)
+      expect(decoded['policies'][4]).to eq(post_policy)
 
       worker_fetch_policy = {
           'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789',
@@ -86,7 +95,7 @@ describe Twilio::TaskRouter::Capability do
           'post_filter' => {},
           'allow' => true
       }
-      expect(decoded['policies'][4]).to eq(worker_fetch_policy)
+      expect(decoded['policies'][5]).to eq(worker_fetch_policy)
     end
 
     it 'should add a policy when #allow_worker_activity_updates is called' do

--- a/spec/task_router_worker_spec.rb
+++ b/spec/task_router_worker_spec.rb
@@ -42,7 +42,7 @@ describe Twilio::TaskRouter::WorkerCapability do
     it 'should allow websocket operations and activity list fetches by default' do
       token = @capability.generate_token
       decoded, header = JWT.decode token, 'foobar'
-      expect(decoded['policies'].size).to eq(5)
+      expect(decoded['policies'].size).to eq(6)
       get_policy = {
         "url" => 'https://event-bridge.twilio.com/v1/wschannels/AC123/WK789',
         "method" => 'GET',
@@ -78,14 +78,23 @@ describe Twilio::TaskRouter::WorkerCapability do
       }
       expect(decoded['policies'][3]).to eq(activities_policy)
 
-      reservations_policy = {
+      tasks_policy = {
           'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**',
           'method' => 'GET',
           'query_filter' => {},
           'post_filter' => {},
           'allow' => true
       }
-      expect(decoded['policies'][4]).to eq(reservations_policy)
+      expect(decoded['policies'][4]).to eq(tasks_policy)
+
+      worker_reservations_policy = {
+          'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**',
+          'method' => 'GET',
+          'query_filter' => {},
+          'post_filter' => {},
+          'allow' => true
+      }
+      expect(decoded['policies'][5]).to eq(worker_reservations_policy)
     end
 
     it 'should add a policy when #allow_activity_updates is called' do
@@ -107,7 +116,7 @@ describe Twilio::TaskRouter::WorkerCapability do
       expect(decoded['policies'].size).to eq(policies_size+1)
     end
 
-    it 'should add a policy when #allow_reservation_updates is called' do
+    it 'should add two policies when #allow_reservation_updates is called' do
       token = @capability.generate_token
       decoded, header = JWT.decode token, 'foobar'
       policies_size = decoded['policies'].size
@@ -115,15 +124,23 @@ describe Twilio::TaskRouter::WorkerCapability do
       @capability.allow_reservation_updates
       token = @capability.generate_token
       decoded, header = JWT.decode token, 'foobar'
-      reservation_policy = {
+      tasks_policy = {
         'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**',
         'method' => 'POST',
         'query_filter' => {},
         'post_filter' => {},
         'allow' => true
       }
-      expect(decoded['policies'][-1]).to eq(reservation_policy)
-      expect(decoded['policies'].size).to eq(policies_size+1)
+      expect(decoded['policies'][-2]).to eq(tasks_policy)
+      worker_reservations_policy = {
+          'url' => 'https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**',
+          'method' => 'POST',
+          'query_filter' => {},
+          'post_filter' => {},
+          'allow' => true
+      }
+      expect(decoded['policies'][-1]).to eq(worker_reservations_policy)
+      expect(decoded['policies'].size).to eq(policies_size+2)
     end
   end
 end


### PR DESCRIPTION
- Allow fetching Reservations under a Worker by default
- Allow updating Reservations under a Worker