### PR TITLE
Allow block configuration of API Keys with associated tests and documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,6 +22,7 @@ A huge thanks to all of our contributors:
 - Joël Franusic
 - K Gautam Pai
 - Karl Freeman
+- Kelley Reynolds
 - Kevin Burke
 - Kyle Conroy
 - Leo Adamek

--- a/README.md
+++ b/README.md
@@ -43,10 +43,37 @@ auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
 # set up a client to talk to the Twilio REST API
 @client = Twilio::REST::Client.new account_sid, auth_token
 
+
 # alternatively, you can preconfigure the client like so
 Twilio.configure do |config|
   config.account_sid = account_sid
   config.auth_token = auth_token
+end
+
+# and then you can create a new client without parameters
+@client = Twilio::REST::Client.new
+```
+
+### Setup Work Using an API Key
+
+``` ruby
+require 'rubygems' # not necessary with ruby 1.9 but included for completeness
+require 'twilio-ruby'
+
+# put your own credentials here
+account_sid = 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy' # Use the auth_token of the API Key
+username = 'SKzzzzzzzzzzzzzzzzzzzzzzzzzzzz' # Use the key_sid of the API Key
+
+# set up a client to talk to the Twilio REST API
+# Note: The username is first and the account_sid is last
+@client = Twilio::REST::Client.new username, auth_token, account_sid
+
+# alternatively, you can preconfigure the client like so
+Twilio.configure do |config|
+  config.account_sid = account_sid
+  config.auth_token = auth_token
+  config.username = username
 end
 
 # and then you can create a new client without parameters

--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -115,7 +115,7 @@ require 'rack/twilio_webhook_authentication'
 module Twilio
   extend SingleForwardable
 
-  def_delegators :configuration, :account_sid, :auth_token
+  def_delegators :configuration, :account_sid, :auth_token, :username
 
   ##
   # Pre-configure with account SID and auth token so that you don't need to

--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -19,14 +19,14 @@ module Twilio
         @host = host
       end
 
-      attr_reader :account_sid, :last_request, :last_response
+      attr_reader :account_sid, :username, :last_request, :last_response
 
       def initialize(*args)
         options = args.last.is_a?(Hash) ? args.pop : {}
         options[:host] ||= self.class.host
         @config = Twilio::Util::ClientConfig.new options
 
-        @username = args[0] || Twilio.account_sid
+        @username = args[0] || Twilio.username || Twilio.account_sid
         @auth_token = args[1] || Twilio.auth_token
         @account_sid = (args.size > 2 && args[2].is_a?(String) ? args[2] : args[0]) || Twilio.account_sid
         if @account_sid.nil? || @auth_token.nil?

--- a/lib/twilio-ruby/util/configuration.rb
+++ b/lib/twilio-ruby/util/configuration.rb
@@ -1,7 +1,7 @@
 module Twilio
   module Util
     class Configuration
-      attr_accessor :account_sid, :auth_token
+      attr_accessor :account_sid, :auth_token, :username
     end
   end
 end

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -6,7 +6,7 @@ describe Twilio::REST::Client do
       Twilio.instance_variable_set('@configuration', nil)
     end
 
-    it 'should set the account sid and auth token with a config block' do
+    it 'should set the username to the account_sid if not specified' do
       Twilio.configure do |config|
         config.account_sid = 'someSid'
         config.auth_token = 'someToken'
@@ -14,17 +14,32 @@ describe Twilio::REST::Client do
 
       client = Twilio::REST::Client.new
       expect(client.account_sid).to eq('someSid')
-      expect(client.instance_variable_get('@auth_token')).to eq('someToken')
+      expect(client.username).to eq('someSid')
     end
 
-    it 'should overwrite account sid and auth token if passed to initializer' do
+    it 'should set the account sid, auth token, and username with a config block' do
       Twilio.configure do |config|
         config.account_sid = 'someSid'
         config.auth_token = 'someToken'
+        config.username = 'someUsername'
       end
 
-      client = Twilio::REST::Client.new 'otherSid', 'otherToken'
+      client = Twilio::REST::Client.new
+      expect(client.account_sid).to eq('someSid')
+      expect(client.username).to eq('someUsername')
+      expect(client.instance_variable_get('@auth_token')).to eq('someToken')
+    end
+
+    it 'should overwrite account sid, auth token, and username if passed to initializer' do
+      Twilio.configure do |config|
+        config.account_sid = 'someSid'
+        config.auth_token = 'someToken'
+        config.auth_token = 'someUsername'
+      end
+
+      client = Twilio::REST::Client.new 'otherUsername', 'otherToken', 'otherSid'
       expect(client.account_sid).to eq('otherSid')
+      expect(client.username).to eq('otherUsername')
       expect(client.instance_variable_get('@auth_token')).to eq('otherToken')
     end
 

--- a/spec/util/configuration_spec.rb
+++ b/spec/util/configuration_spec.rb
@@ -12,4 +12,10 @@ describe Twilio::Util::Configuration do
     config.auth_token = 'someToken'
     expect(config.auth_token).to eq('someToken')
   end
+
+  it 'should have a username attribute' do
+    config = Twilio::Util::Configuration.new
+    config.username = 'someUsername'
+    expect(config.username).to eq('someUsername')
+  end
 end


### PR DESCRIPTION
There is no way to know how to use an API Key with the ruby client without reading the source, and its not possible to configure it with the block configurator. I've added the ability to set the username in a configuration block as well as modified the documentation to show how it should be done with an API key.
