### PR TITLE
Updates request validator to avoid issues with ActionController::Parameters

### DIFF
--- a/lib/twilio-ruby/util/request_validator.rb
+++ b/lib/twilio-ruby/util/request_validator.rb
@@ -8,7 +8,8 @@ module Twilio
       end
 
       def validate(url, params, signature)
-        expected = build_signature_for url, params
+        params_hash = params_to_hash(params)
+        expected = build_signature_for url, params_hash
         secure_compare(expected, signature)
       end
 
@@ -31,6 +32,23 @@ module Twilio
         res = 0
         b.each_byte { |byte| res |= byte ^ l.shift }
         res == 0
+      end
+
+      # `ActionController::Parameters` no longer, as of Rails 5, inherits
+      # from `Hash` so the `sort` method, used above in `build_signature_for`
+      # is deprecated.
+      #
+      # `to_unsafe_h` was introduced in Rails 4.2.1, before then it is still
+      # possible to sort on an ActionController::Parameters object.
+      #
+      # We use `to_unsafe_h` as `to_h` returns a hash of the permitted
+      # parameters only and we need all the parameters to create the signature.
+      def params_to_hash(params)
+        if params.respond_to?(:to_unsafe_h)
+          params.to_unsafe_h
+        else
+          params
+        end
       end
     end
   end

--- a/spec/support/action_controller_parameters.rb
+++ b/spec/support/action_controller_parameters.rb
@@ -1,0 +1,17 @@
+# A fake version of `ActionController::Parameters` for testing with.
+#
+# Since Rails 5, `ActionController::Parameters` doesn't inherit from `Hash` so
+# hash methods, like `sort` which is used in `Twilio::Util::RequestValidator`
+# are being deprecated. See the discussion here:
+# https://github.com/rails/rails/issues/23084.
+module ActionController
+  class Parameters < Hash
+    def to_unsafe_h
+      self.to_h
+    end
+
+    def sort
+      raise "Can't sort directly on ActionController::Parameters"
+    end
+  end
+end

--- a/spec/support/action_controller_parameters.rb
+++ b/spec/support/action_controller_parameters.rb
@@ -7,7 +7,9 @@
 module ActionController
   class Parameters < Hash
     def to_unsafe_h
-      self.to_h
+      # Creates a new Hash using the values of this hash. We could use `to_h`
+      # Once Ruby 1.9.3 is dropped from CI.
+      Hash[self]
     end
 
     def sort

--- a/spec/util/request_validator_spec.rb
+++ b/spec/util/request_validator_spec.rb
@@ -95,9 +95,21 @@ describe Twilio::Util::RequestValidator do
       expect(validator.validate(voice_url, voice_params, signature)).to eq(true)
     end
 
+    it 'should validate an authentic Twilio Voice request from ActionController::Parameters' do
+      signature = 'oVb2kXoVy8GEfwBDjR8bk/ZZ6eA='
+      params = ActionController::Parameters[voice_params]
+      expect(validator.validate(voice_url, params, signature)).to eq(true)
+    end
+
     it 'should validate an authentic Twilio SMS request' do
       signature = 'mxeiv65lEe0b8L6LdVw2jgJi8yw='
       expect(validator.validate(sms_url, sms_params, signature)).to eq(true)
+    end
+
+    it 'should validate an authentic Twilio SMS request from ActionController::Parameters' do
+      signature = 'mxeiv65lEe0b8L6LdVw2jgJi8yw='
+      params = ActionController::Parameters[sms_params]
+      expect(validator.validate(sms_url, params, signature)).to eq(true)
     end
 
     it 'should not validate a Twilio Voice request with wrong signature' do


### PR DESCRIPTION
From Rails 5.1 the Hash methods on `ActionController::Parameters` will be removed, from Rails 5 they are deprecated. This is because `ActionController::Parameters` no longer inherits from `Hash` (well, `ActiveSupport::HashWithIndifferentAccess`, but who's counting?).

`Twilio::Util::RequestValidator` users `Hash#sort`, so we need to convert an `ActionController::Parameters` object to a hash so that we can continue to validate requests in this way.
