### PR TITLE
Allow repeated parameter names for lookup requests

### DIFF
--- a/lib/twilio-ruby/rest/utils.rb
+++ b/lib/twilio-ruby/rest/utils.rb
@@ -13,8 +13,7 @@ module Twilio
 
       def detwilify(something)
         return key_map(something, :detwilify) if something.is_a? Hash
-        return array_map(something, :detwilify)
-          .map { |p| [p.first.to_sym, p.last ] } if something.is_a?(Array)
+        return array_map(something, :detwilify) if something.is_a?(Array)
         string = something.to_s
         string = string[0,1].downcase + string[1..-1]
         string.gsub(/[A-Z][a-z]*/) { |s| "_#{s.downcase}" }

--- a/lib/twilio-ruby/rest/utils.rb
+++ b/lib/twilio-ruby/rest/utils.rb
@@ -4,6 +4,7 @@ module Twilio
 
       def twilify(something)
         return key_map(something, :twilify) if something.is_a? Hash
+        return array_map(something, :twilify) if something.is_a?(Array)
         string = something.to_s
         string.split('_').map do |string_part|
           string_part[0,1].capitalize + string_part[1..-1]
@@ -12,6 +13,8 @@ module Twilio
 
       def detwilify(something)
         return key_map(something, :detwilify) if something.is_a? Hash
+        return array_map(something, :detwilify)
+          .map { |p| [p.first.to_sym, p.last ] } if something.is_a?(Array)
         string = something.to_s
         string = string[0,1].downcase + string[1..-1]
         string.gsub(/[A-Z][a-z]*/) { |s| "_#{s.downcase}" }
@@ -44,6 +47,13 @@ module Twilio
         end
         Hash[*something]
       end
+
+      # Intended for use on an array of parameter pairs, like
+      # [ [ :type, 'carrier' ], [ :type, 'caller_name'] ]
+      def array_map(something, method)
+        something.map { |pair| [ send(method, pair[0]).to_sym, pair[1].to_s ] }
+      end
+
     end
   end
 end

--- a/spec/rest/utils_spec.rb
+++ b/spec/rest/utils_spec.rb
@@ -42,4 +42,23 @@ describe UtilClass do
     }
     expect(util.detwilify(twilified)).to eq(untwilified)
   end
+
+  it 'should convert an array of pairs to parameter names' do
+    untwilified = [[ :sms_url, 'someUrl' ], [ :voice_fallback_url, 'anotherUrl' ], [ :statusCallback, 'yetAnotherUrl' ]]
+    twilified = [[:SmsUrl, "someUrl"], [:VoiceFallbackUrl, "anotherUrl"], [:StatusCallback, "yetAnotherUrl"]]
+    expect(util.twilify(untwilified)).to eq(twilified)
+  end
+
+  it 'should convert array of pairs of Twilio-style names to parameter names' do
+    twilified = [[:SmsUrl, "someUrl"], [:VoiceFallbackUrl, "anotherUrl"], [:StatusCallback, "yetAnotherUrl"]]
+    untwilified = [[ :sms_url, 'someUrl' ], [ :voice_fallback_url, 'anotherUrl' ], [ :status_callback, 'yetAnotherUrl' ]]
+    expect(util.detwilify(twilified)).to eq(untwilified)
+  end
+
+  it 'should allow duplicate parameter names when converting array of pairs' do
+    untwilified = [[ :type, 'carrier' ], [:other, :foo], [ :type, 'caller-name']]
+    twilified = [[:Type, "carrier"], [:Other, "foo"], [:Type, "caller-name"]]
+    expect(util.twilify(untwilified)).to eq(twilified)
+  end
+
 end

--- a/spec/rest/utils_spec.rb
+++ b/spec/rest/utils_spec.rb
@@ -43,7 +43,7 @@ describe UtilClass do
     expect(util.detwilify(twilified)).to eq(untwilified)
   end
 
-  it 'should convert an array of pairs to parameter names' do
+  it 'should convert an array of pairs to Twilio-style names' do
     untwilified = [[ :sms_url, 'someUrl' ], [ :voice_fallback_url, 'anotherUrl' ], [ :statusCallback, 'yetAnotherUrl' ]]
     twilified = [[:SmsUrl, "someUrl"], [:VoiceFallbackUrl, "anotherUrl"], [:StatusCallback, "yetAnotherUrl"]]
     expect(util.twilify(untwilified)).to eq(twilified)


### PR DESCRIPTION
The API tester at https://www.twilio.com/lookup has a repeated
"Type" parameter in the sample URL:

https://lookups.twilio.com/v1/PhoneNumbers/6156?Type=carrier&Type=caller-name

But because the `twilify` method expects either a hash or something
that can be reasonably stringfied, it is impossible to specify "Type" more
than once.

This change allows one to provide an array of [name,value] pairs as
a parameter list to the phone number lookup's "get", by modifying
twilify() to understand lists of pairs.

With this change you can lookup a phone number like:

`
result = lookup_client.phone_numbers.get(
    '13128675309', [ [ :type, 'carrier' ], [ :type, 'caller-name'] ])
`

...using an array of pairs instead of a hash to represent the parameter list, and thus having repeating parameter names.
