### PR TITLE
Multi url parameters

### DIFF
--- a/docs/usage/lookups.rst
+++ b/docs/usage/lookups.rst
@@ -60,3 +60,25 @@ The Lookups API can be used to find out more information about the carrier for t
     response = @lookups_client.phone_numbers.get("+12316851234", type: "carrier")
     response.carrier
     # => {"mobile_country_code"=>nil, "mobile_network_code"=>nil, "name"=>"Charter Fiberlink, LLC", "type"=>"landline", "error_code"=>nil}
+
+Caller Name
+-----------
+
+You can also use the Lookups API to query the Caller ID Name (CNAM) database that lists many US numbers. This time, pass the type "caller-name" to the request.
+
+.. code-block:: ruby
+
+    response = @lookups_client.phone_numbers.get("+14157012311", type: "caller-name")
+    response.caller_name
+    # => {"caller_name"=>"SAN FRANCISCO TRANSIT - BUS LI", "caller_type"=>"BUSINESS", "error_code"=>nil}
+
+Multiple Types of Lookups
+-------------------------
+
+You can use the Lookups API to check both caller name and carrier information in one API call. Just pass the types you want to look up as an array.
+
+    response = @lookups_client.phone_numbers.get("+14157012311", type: ["caller-name", "carrier"])
+    response.caller_name
+    # => {"caller_name"=>"SAN FRANCISCO TRANSIT - BUS LI", "caller_type"=>"BUSINESS", "error_code"=>nil}
+    response.carrier
+    # => {"mobile_country_code"=>nil, "mobile_network_code"=>nil, "name"=>"Pacific Bell", "type"=>"landline", "error_code"=>nil}

--- a/lib/twilio-ruby/util.rb
+++ b/lib/twilio-ruby/util.rb
@@ -1,7 +1,16 @@
 module Twilio
   module Util
     def url_encode(hash)
-      hash.to_a.map {|p| p.map {|e| CGI.escape get_string(e)}.join '='}.join '&'
+      normalized_parameters = hash.inject([]) do |memo, (key, value)|
+        key = CGI.escape(get_string(key))
+        if value.is_a?(Array)
+          value.each { |arg| memo << [key, CGI.escape(get_string(arg))] }
+        else
+          memo << [key, CGI.escape(get_string(value))]
+        end
+        memo
+      end
+      normalized_parameters.map { |pair| pair.join("=") }.join("&")
     end
 
     def get_string(obj)

--- a/spec/util/url_encode_spec.rb
+++ b/spec/util/url_encode_spec.rb
@@ -3,10 +3,24 @@ require 'spec_helper'
 describe Twilio::Util do
   include Twilio::Util
 
+  it 'should turn a hash into a url encoded string of parameters' do
+    hash = { :param => 'test', :param2 => 'hello monkey', :param3 => '<3' }
+    url = url_encode(hash)
+
+    expect(url).to eq('param=test&param2=hello+monkey&param3=%3C3')
+  end
+
   it 'should parse a Date object' do
     today = Time.now
     url = url_encode('DateSent>' => today)
 
     expect(url).to eq("DateSent%3E=#{today.strftime('%Y-%m-%d')}")
+  end
+
+  it 'should turn an array into multiple keys in the path' do
+    hash = { :param => 'test', :type => ['carrier', 'caller-name'] }
+    url = url_encode(hash)
+
+    expect(url).to eq('param=test&type=carrier&type=caller-name')
   end
 end


### PR DESCRIPTION
Inspired by #200.

You should be able to use multiple parameters, like in the lookups API, by passing an array of parameters. That will then get written out as a repeated parameters in the URL. For example:

```
@lookups_client.phone_numbers.get("+14157012311", type: ["caller-name", "carrier"])
```

Will produce the URL 

> https://lookups.twilio.com/v1/{{ Account SID }}/PhoneNumber/+14157012311?Type=caller-name&Type=carrier

Updated the Lookups docs accordingly.
