### PR TITLE
Removes activesupport dependency.

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('builder', '>= 2.1.2')
   spec.add_dependency('jwt', '~> 1.0')
-  spec.add_dependency('activesupport', '~> 4.2')
   spec.add_dependency('faraday', '~>0.9')
   spec.add_dependency('jruby-openssl') if RUBY_PLATFORM == 'java'
   # Workaround for RBX <= 2.2.1, should be fixed in next version


### PR DESCRIPTION
All tests pass so I'm guessing the work to actually remove the dependency has been done already. Just needed to remove the gem from the gemspec.