### PR TITLE
Removes end of lifed 1.9.3 from TravisCI. Adds 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ bundler_args: --without development
 rvm:
   - ruby-head
   - ruby
+  - 2.3.0
   - 2.2.0
   - 2.1.0
   - 2.0.0
-  - 1.9.3
   - jruby-head
   - jruby
   - jruby-19mode


### PR DESCRIPTION
2.0.0 is also at end of life, but can still be [downloaded from ruby-lang](https://www.ruby-lang.org/en/downloads/) so keeping it for now.
