### PR TITLE
Avoids issues with ActionController::Parameters in next-gen branch

### DIFF
--- a/spec/security/request_validator_spec.rb
+++ b/spec/security/request_validator_spec.rb
@@ -95,9 +95,21 @@ describe Twilio::Security::RequestValidator do
       expect(validator.validate(voice_url, voice_params, signature)).to eq(true)
     end
 
+    it 'should validate an authentic Twilio Voice request from ActionController::Parameters' do
+      signature = 'oVb2kXoVy8GEfwBDjR8bk/ZZ6eA='
+      params = ActionController::Parameters[voice_params]
+      expect(validator.validate(voice_url, params, signature)).to eq(true)
+    end
+
     it 'should validate an authentic Twilio SMS request' do
       signature = 'mxeiv65lEe0b8L6LdVw2jgJi8yw='
       expect(validator.validate(sms_url, sms_params, signature)).to eq(true)
+    end
+
+    it 'should validate an authentic Twilio SMS request from ActionController::Parameters' do
+      signature = 'mxeiv65lEe0b8L6LdVw2jgJi8yw='
+      params = ActionController::Parameters[sms_params]
+      expect(validator.validate(sms_url, params, signature)).to eq(true)
     end
 
     it 'should not validate a Twilio Voice request with wrong signature' do

--- a/spec/support/action_controller_parameters.rb
+++ b/spec/support/action_controller_parameters.rb
@@ -1,0 +1,19 @@
+# A fake version of `ActionController::Parameters` for testing with.
+#
+# Since Rails 5, `ActionController::Parameters` doesn't inherit from `Hash` so
+# hash methods, like `sort` which is used in `Twilio::Util::RequestValidator`
+# are being deprecated. See the discussion here:
+# https://github.com/rails/rails/issues/23084.
+module ActionController
+  class Parameters < Hash
+    def to_unsafe_h
+      # Creates a new Hash using the values of this hash. We could use `to_h`
+      # Once Ruby 1.9.3 is dropped from CI.
+      Hash[self]
+    end
+
+    def sort
+      raise "Can't sort directly on ActionController::Parameters"
+    end
+  end
+end


### PR DESCRIPTION
From Rails 5.1 the `Hash` methods on `ActionController::Parameters` will be removed, from Rails 5 they are deprecated. This is because `ActionController::Parameters` no longer inherits from `Hash` (well, `ActiveSupport::HashWithIndifferentAccess`, but who's counting?).

`Twilio::Util::RequestValidator` users `Hash#sort`, so we need to convert an `ActionController::Parameters` object to a `Hash` so that we can continue to validate requests in this way.
