### PR TITLE
Fixes use of configuration in client.

### DIFF
--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -14,8 +14,8 @@ module Twilio
       ##
       # Initializes the Twilio Client
       def initialize(username=nil, password=nil, account_sid=nil, http_client=Twilio::HTTP::Client.new)
-        @username = username || Twilio.configuration.account_sid
-        @password = password || Twilio.configuration.auth_token
+        @username = username || Twilio.account_sid
+        @password = password || Twilio.auth_token
         @account_sid = account_sid || @username
         @auth_token = @password
         @auth = [@username, @password]


### PR DESCRIPTION
As reported in #227, when you rely on the config set in the `Twilio.configure` block, the client tries to use the private class method configuration to access the `account_sid` and `auth_token`. There are direct readers for this on the Twilio module which we should use instead.

I've made this a pull request just to highlight the change though I understand that this is part of the generated code.