### PR TITLE
Fix exception in the RestException#to_s method

### DIFF
--- a/lib/twilio-ruby/framework/exception.rb
+++ b/lib/twilio-ruby/framework/exception.rb
@@ -23,7 +23,7 @@ module Twilio
       end
 
       def to_s
-        "[HTTP #{status_code}] #{code} : #{msg}"
+        "[HTTP #{status_code}] #{code} : #{message}"
       end
     end
   end


### PR DESCRIPTION
Hit this bug in 5.0.0.rc14

```
#<NameError: undefined local variable or method `msg' for #<Twilio::REST::RestException:0x007ff1b48599d8>
/Users/matthew/.gem/ruby/2.3.1/gems/twilio-ruby-5.0.0.rc14/lib/twilio-ruby/framework/exception.rb:26:in `to_s'
```
