### PR TITLE
Add properties method to instance resource

### DIFF
--- a/lib/twilio-ruby/rest/instance_resource.rb
+++ b/lib/twilio-ruby/rest/instance_resource.rb
@@ -74,6 +74,8 @@ module Twilio
 
       def set_up_properties_from(hash)
         eigenclass = class << self; self; end
+        eigenclass.send :define_method, :properties, &lambda { hash }
+
         hash.each do |p,v|
           property = detwilify p
           unless ['client', 'updated'].include? property

--- a/spec/rest/instance_resource_spec.rb
+++ b/spec/rest/instance_resource_spec.rb
@@ -12,4 +12,10 @@ describe Twilio::REST::InstanceResource do
     resource = Twilio::REST::InstanceResource.new('uri', 'client', params)
     expect(resource.some_key).to eq('someValue')
   end
+
+  it 'should expose the properties method' do
+    params = { 'SomeKey' => 'someValue' }
+    resource = Twilio::REST::InstanceResource.new('uri', 'client', params)
+    expect(resource.properties).to eq({ 'SomeKey' => 'someValue' })
+  end
 end


### PR DESCRIPTION
The twilio-ruby gem is fantastic however I wish there was a method I could call to quickly inspect the state of a resource.

This PR adds a `properties` method to the instance resource class. So the following is now possible:
```ruby
irb(main):003:0> twilio_client.account.messages.list.first.properties
=> 
{
  "sid"=>"sid", 
  "date_created"=>"Thu, 01 Dec 2016 15:51:43 +0000", 
  "date_updated"=>"Thu, 01 Dec 2016 15:51:43 +0000", 
  "date_sent"=>"Thu, 01 Dec 2016 15:51:43 +0000", 
  "account_sid"=>"sid", 
  "to"=>"+123", 
  "from"=>"+456", 
  .
  .
}
```

This is just a POC, I'm open to having a discussion about the approach. Maybe this type of method already exists?

Thanks!