### PR TITLE
Made Twilio error description 'NewRelic - friendly

### DIFF
--- a/lib/twilio-ruby/rest/errors.rb
+++ b/lib/twilio-ruby/rest/errors.rb
@@ -9,6 +9,10 @@ module Twilio
         super message
         @code = code
       end
+
+      def to_s
+        "#{code} - #{message}"
+      end
     end
   end
 end


### PR DESCRIPTION
When there is a Twilio error, New Relic picks up it and displays the stack trace and the exception message. The trouble is, without the Twilio error code, it is very hard to figure out why Twilio threw an exception. This PR will allow Twilio error code to be automatically displayed as a part of exception text