### PR TITLE
Making message and code accessible when response is a kind of Net::HT…

### DIFF
--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -118,7 +118,7 @@ module Twilio
         if response.body and !response.body.empty?
           object = MultiJson.load response.body
         elsif response.kind_of? Net::HTTPBadRequest
-          object = { message: 'Bad request', code: 400 }
+          object = HashWithIndifferentAccess.new('message' => 'Bad request', 'code' => 400)
         end
 
         if response.kind_of? Net::HTTPClientError


### PR DESCRIPTION
…TPBadRequest

Net::HTTPClientError is the parent of Net::HTTPBadRequest.

But when the response is a Net::HTTPBadRequest, the object hash uses symbols as keys, not strings.  So the Twilio::REST::RequestError created in line 125 would not have the message or the code values.

I don't know how object will be used when returned by this method (laziness!), so making object an instance of HashWithIndifferentAccess when set in line 121, so that either type of key can be used.