### PR TITLE
Making message, code accessible when response is kind of HTTPBadRequest

### DIFF
--- a/lib/twilio-ruby/rest/base_client.rb
+++ b/lib/twilio-ruby/rest/base_client.rb
@@ -118,7 +118,7 @@ module Twilio
         if response.body and !response.body.empty?
           object = MultiJson.load response.body
         elsif response.kind_of? Net::HTTPBadRequest
-          object = { message: 'Bad request', code: 400 }
+          object = { 'message' => 'Bad request', 'code' => 400 }
         end
 
         if response.kind_of? Net::HTTPClientError


### PR DESCRIPTION
…TPBadRequest

Net::HTTPClientError is the parent of Net::HTTPBadRequest.

But when the response is a Net::HTTPBadRequest, the object hash uses symbols as keys, not strings. So the Twilio::REST::RequestError created in line 125 would not have the message or the code values.

The hash returned by connect_and_send is not used by the caller so using string keys when it is set in line 121 enables these keys to be used in line 125.