### PR TITLE
Use #strict_encode64 instead of #encode64 in RequestValidator

### DIFF
--- a/lib/twilio-ruby/util/request_validator.rb
+++ b/lib/twilio-ruby/util/request_validator.rb
@@ -15,7 +15,7 @@ module Twilio
       def build_signature_for(url, params)
         data = url + params.sort.join
         digest = OpenSSL::Digest.new('sha1')
-        Base64.encode64(OpenSSL::HMAC.digest(digest, @auth_token, data)).strip
+        Base64.strict_encode64(OpenSSL::HMAC.digest(digest, @auth_token, data)).strip
       end
 
       private


### PR DESCRIPTION
#encode64 and #strict_encode64 are equivalent for inputs <60 bytes. If twilio-ruby ever switches to a HMAC-SHA-256 or bigger hash, the base64 output would start having newlines and that won't work in an HTTP header. Switching to a bigger hash is something that might happen, given sha1 problems.

Hat tip 🎩  to @keithduncan for the explanation.