### PR TITLE
Don't allow blocks for TwiML elements that don't nest.

### DIFF
--- a/lib/twilio-ruby/twiml/messaging_response.rb
+++ b/lib/twilio-ruby/twiml/messaging_response.rb
@@ -23,22 +23,22 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Message> child element
       def message(
-          body,
-          to: nil,
-          from: nil,
-          method: nil,
-          action: nil,
-          status_callback: nil,
-          **keyword_args)
+        body,
+        to: nil,
+        from: nil,
+        method: nil,
+        action: nil,
+        status_callback: nil,
+        **keyword_args)
 
         message = Message.new(
-            body: body,
-            to: to,
-            from: from,
-            method: method,
-            action: action,
-            status_callback: status_callback,
-            **keyword_args
+          body: body,
+          to: to,
+          from: from,
+          method: method,
+          action: action,
+          status_callback: status_callback,
+          **keyword_args
         )
 
         yield(message) if block_given?
@@ -56,11 +56,7 @@ module Twilio
       # == Returns:
       # A <Response> element with an <Redirect> child element
       def redirect(url, method: nil, **keyword_args)
-        redirect = Redirect.new(url, method: method, **keyword_args)
-
-        yield(redirect) if block_given?
-
-        self.append(redirect)
+        self.append(Redirect.new(url, method: method, **keyword_args))
       end
     end
 
@@ -90,11 +86,7 @@ module Twilio
       # == Returns:
       # A <Message> element with a <Body> child element
       def body(body)
-        body = Body.new(body)
-
-        yield(body) if block_given?
-
-        self.append(body)
+        self.append(Body.new(body))
       end
 
       # Create a <Media> element
@@ -106,11 +98,7 @@ module Twilio
       # == Returns:
       # A <Message> element with a <Media> child element
       def media(url)
-        media = Media.new(url)
-
-        yield(media) if block_given?
-
-        self.append(media)
+        self.append(Media.new(url))
       end
     end
 

--- a/lib/twilio-ruby/twiml/voice_response.rb
+++ b/lib/twilio-ruby/twiml/voice_response.rb
@@ -69,11 +69,7 @@ module Twilio
       # == Returns:
       # A <Response> element with an <Echo> child element
       def echo(**keyword_args)
-        echo = Echo.new(**keyword_args)
-
-        yield(echo) if block_given?
-
-        self.append(echo)
+        self.append(Echo.new(**keyword_args))
       end
 
       # Create an <Enqueue> element
@@ -90,22 +86,22 @@ module Twilio
       # == Returns:
       # A <Response> element with an <Enqueue> child element
       def enqueue(
-          name,
-          action: nil,
-          method: nil,
-          wait_url: nil,
-          wait_url_method: nil,
-          workflow_sid: nil,
-          **keyword_args)
+        name,
+        action: nil,
+        method: nil,
+        wait_url: nil,
+        wait_url_method: nil,
+        workflow_sid: nil,
+        **keyword_args)
 
         enqueue = Enqueue.new(
-            name,
-            action: action,
-            method: method,
-            wait_url: wait_url,
-            wait_url_method: wait_url_method,
-            workflow_sid: workflow_sid,
-            **keyword_args
+          name,
+          action: action,
+          method: method,
+          wait_url: wait_url,
+          wait_url_method: wait_url_method,
+          workflow_sid: workflow_sid,
+          **keyword_args
         )
 
         yield(enqueue) if block_given?
@@ -132,32 +128,32 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Gather> child element
       def gather(
-          action: nil,
-          method: nil,
-          timeout: nil,
-          finish_on_key: nil,
-          num_digits: nil,
-          partial_result_callback: nil,
-          partial_result_callback_method: nil,
-          language: nil,
-          hints: nil,
-          barge_in: nil,
-          acknowledge_sound_url: nil,
-          **keyword_args)
+        action: nil,
+        method: nil,
+        timeout: nil,
+        finish_on_key: nil,
+        num_digits: nil,
+        partial_result_callback: nil,
+        partial_result_callback_method: nil,
+        language: nil,
+        hints: nil,
+        barge_in: nil,
+        acknowledge_sound_url: nil,
+        **keyword_args)
 
         gather = Gather.new(
-            action: action,
-            method: method,
-            timeout: timeout,
-            finish_on_key: finish_on_key,
-            num_digits: num_digits,
-            partial_result_callback: partial_result_callback,
-            partial_result_callback_method: partial_result_callback_method,
-            language: language,
-            hints: hints,
-            barge_in: barge_in,
-            acknowledge_sound_url: acknowledge_sound_url,
-            **keyword_args
+          action: action,
+          method: method,
+          timeout: timeout,
+          finish_on_key: finish_on_key,
+          num_digits: num_digits,
+          partial_result_callback: partial_result_callback,
+          partial_result_callback_method: partial_result_callback_method,
+          language: language,
+          hints: hints,
+          barge_in: barge_in,
+          acknowledge_sound_url: acknowledge_sound_url,
+          **keyword_args
         )
 
         yield(gather) if block_given?
@@ -170,11 +166,7 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Hangup> child element
       def hangup()
-        hangup = Hangup.new
-
-        yield(hangup) if block_given?
-
-        self.append(hangup)
+        self.append(Hangup.new)
       end
 
       # Create a <Leave> element
@@ -182,11 +174,7 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Leave> child element
       def leave()
-        leave = Leave.new
-
-        yield(leave) if block_given?
-
-        self.append(leave)
+        self.append(Leave.new)
       end
 
       # Create a <Pause> element
@@ -197,11 +185,7 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Pause> child element
       def pause(length: nil)
-        pause = Pause.new(length: length)
-
-        yield(pause) if block_given?
-
-        self.append(pause)
+        self.append(Pause.new(length: length))
       end
 
       # Create a <Play> element
@@ -215,11 +199,12 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Play> child element
       def play(url: nil, loop: nil, digits: nil, **keyword_args)
-        play = Play.new(url: url, loop: loop, digits: digits, **keyword_args)
-
-        yield(play) if block_given?
-
-        self.append(play)
+        self.append(Play.new(
+          url: url,
+          loop: loop,
+          digits: digits,
+          **keyword_args
+        ))
       end
 
       # Create a <Record> element
@@ -241,37 +226,32 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Record> child element
       def record(
-          action: nil,
-          method: nil,
-          timeout: nil,
-          finish_on_key: nil,
-          max_length: nil,
-          play_beep: nil,
-          trim: nil,
-          recording_status_callback: nil,
-          recording_status_callback_method: nil,
-          transcribe: nil,
-          transcribe_callback: nil,
-          **keyword_args)
-
-        record = Record.new(
-            action: action,
-            method: method,
-            timeout: timeout,
-            finish_on_key: finish_on_key,
-            max_length: max_length,
-            play_beep: play_beep,
-            trim: trim,
-            recording_status_callback: recording_status_callback,
-            recording_status_callback_method: recording_status_callback_method,
-            transcribe: transcribe,
-            transcribe_callback: transcribe_callback,
-            **keyword_args
-        )
-
-        yield(record) if block_given?
-
-        self.append(record)
+        action: nil,
+        method: nil,
+        timeout: nil,
+        finish_on_key: nil,
+        max_length: nil,
+        play_beep: nil,
+        trim: nil,
+        recording_status_callback: nil,
+        recording_status_callback_method: nil,
+        transcribe: nil,
+        transcribe_callback: nil,
+        **keyword_args)
+        self.append(Record.new(
+          action: action,
+          method: method,
+          timeout: timeout,
+          finish_on_key: finish_on_key,
+          max_length: max_length,
+          play_beep: play_beep,
+          trim: trim,
+          recording_status_callback: recording_status_callback,
+          recording_status_callback_method: recording_status_callback_method,
+          transcribe: transcribe,
+          transcribe_callback: transcribe_callback,
+          **keyword_args
+        ))
       end
 
       # Create a <Redirect> element
@@ -284,11 +264,7 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Redirect> child element
       def redirect(url, method: nil, **keyword_args)
-        redirect = Redirect.new(url, method: method, **keyword_args)
-
-        yield(redirect) if block_given?
-
-        self.append(redirect)
+        self.append(Redirect.new(url, method: method, **keyword_args))
       end
 
       # Create a <Reject> element
@@ -300,11 +276,7 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Reject> child element
       def reject(reason: nil, **keyword_args)
-        reject = Reject.new(reason: reason, **keyword_args)
-
-        yield(reject) if block_given?
-
-        self.append(reject)
+        self.append(Reject.new(reason: reason, **keyword_args))
       end
 
       # Create a <Say> element
@@ -319,17 +291,13 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Say> child element
       def say(body, loop: nil, language: nil, voice: nil, **keyword_args)
-        say = Say.new(
-            body,
-            loop: loop,
-            language: language,
-            voice: voice,
-            **keyword_args
-        )
-
-        yield(say) if block_given?
-
-        self.append(say)
+        self.append(Say.new(
+          body,
+          loop: loop,
+          language: language,
+          voice: voice,
+          **keyword_args
+        ))
       end
 
       # Create a <Sms> element
@@ -346,27 +314,22 @@ module Twilio
       # == Returns:
       # A <Response> element with a <Sms> child element
       def sms(
+        body,
+        to: nil,
+        from: nil,
+        method: nil,
+        action: nil,
+        status_callback: nil,
+        **keyword_args)
+        self.append(Sms.new(
           body,
-          to: nil,
-          from: nil,
-          method: nil,
-          action: nil,
-          status_callback: nil,
-          **keyword_args)
-
-        sms = Sms.new(
-            body,
-            to: to,
-            from: from,
-            method: method,
-            action: action,
-            status_callback: status_callback,
-            **keyword_args
-        )
-
-        yield(sms) if block_given?
-
-        self.append(sms)
+          to: to,
+          from: from,
+          method: method,
+          action: action,
+          status_callback: status_callback,
+          **keyword_args
+        ))
       end
     end
 
@@ -401,27 +364,22 @@ module Twilio
       # == Returns:
       # A <Dial> element with a <Client> child element
       def client(
+        name,
+        method: nil,
+        url: nil,
+        status_callback_event: nil,
+        status_callback_method: nil,
+        status_callback: nil,
+        **keyword_args)
+        self.append(Client.new(
           name,
-          method: nil,
-          url: nil,
-          status_callback_event: nil,
-          status_callback_method: nil,
-          status_callback: nil,
-          **keyword_args)
-
-        client = Client.new(
-            name,
-            method: method,
-            url: url,
-            status_callback_event: status_callback_event,
-            status_callback_method: status_callback_method,
-            status_callback: status_callback,
-            **keyword_args
-        )
-
-        yield(client) if block_given?
-
-        self.append(client)
+          method: method,
+          url: url,
+          status_callback_event: status_callback_event,
+          status_callback_method: status_callback_method,
+          status_callback: status_callback,
+          **keyword_args
+        ))
       end
 
       # Create a <Conference> element
@@ -448,47 +406,42 @@ module Twilio
       # == Returns:
       # A <Dial> element with a <Conference> child element
       def conference(
+        name,
+        muted: nil,
+        start_conference_on_enter: nil,
+        end_conference_on_exit: nil,
+        max_participants: nil,
+        beep: nil,
+        record: nil,
+        trim: nil,
+        wait_url: nil,
+        wait_method: nil,
+        event_callback_url: nil,
+        status_callback: nil,
+        status_callback_event: nil,
+        status_callback_method: nil,
+        recording_status_callback: nil,
+        recording_status_callback_method: nil,
+        **keyword_args)
+        self.append(Conference.new(
           name,
-          muted: nil,
-          start_conference_on_enter: nil,
-          end_conference_on_exit: nil,
-          max_participants: nil,
-          beep: nil,
-          record: nil,
-          trim: nil,
-          wait_url: nil,
-          wait_method: nil,
-          event_callback_url: nil,
-          status_callback: nil,
-          status_callback_event: nil,
-          status_callback_method: nil,
-          recording_status_callback: nil,
-          recording_status_callback_method: nil,
-          **keyword_args)
-
-        conference = Conference.new(
-            name,
-            muted: muted,
-            start_conference_on_enter: start_conference_on_enter,
-            end_conference_on_exit: end_conference_on_exit,
-            max_participants: max_participants,
-            beep: beep,
-            record: record,
-            trim: trim,
-            wait_url: wait_url,
-            wait_method: wait_method,
-            event_callback_url: event_callback_url,
-            status_callback: status_callback,
-            status_callback_event: status_callback_event,
-            status_callback_method: status_callback_method,
-            recording_status_callback: recording_status_callback,
-            recording_status_callback_method: recording_status_callback_method,
-            **keyword_args
-        )
-
-        yield(conference) if block_given?
-
-        self.append(conference)
+          muted: muted,
+          start_conference_on_enter: start_conference_on_enter,
+          end_conference_on_exit: end_conference_on_exit,
+          max_participants: max_participants,
+          beep: beep,
+          record: record,
+          trim: trim,
+          wait_url: wait_url,
+          wait_method: wait_method,
+          event_callback_url: event_callback_url,
+          status_callback: status_callback,
+          status_callback_event: status_callback_event,
+          status_callback_method: status_callback_method,
+          recording_status_callback: recording_status_callback,
+          recording_status_callback_method: recording_status_callback_method,
+          **keyword_args
+        ))
       end
 
       # Create a <Number> element
@@ -506,29 +459,24 @@ module Twilio
       # == Returns:
       # A <Dial> element with a <Number> child element
       def number(
+        number,
+        send_digits: nil,
+        url: nil,
+        method: nil,
+        status_callback: nil,
+        status_callback_event: nil,
+        status_callback_method: nil,
+        **keyword_args)
+        self.append(Number.new(
           number,
-          send_digits: nil,
-          url: nil,
-          method: nil,
-          status_callback: nil,
-          status_callback_event: nil,
-          status_callback_method: nil,
-          **keyword_args)
-
-        number = Number.new(
-            number,
-            send_digits: send_digits,
-            url: url,
-            method: method,
-            status_callback: status_callback,
-            status_callback_event: status_callback_event,
-            status_callback_method: status_callback_method,
-            **keyword_args
-        )
-
-        yield(number) if block_given?
-
-        self.append(number)
+          send_digits: send_digits,
+          url: url,
+          method: method,
+          status_callback: status_callback,
+          status_callback_event: status_callback_event,
+          status_callback_method: status_callback_method,
+          **keyword_args
+        ))
       end
 
       # Create a <Queue> element
@@ -544,25 +492,20 @@ module Twilio
       # == Returns:
       # A <Dial> element with a <Queue> child element
       def queue(
+        queue_name,
+        url: nil,
+        method: nil,
+        reservation_sid: nil,
+        post_work_activity_sid: nil,
+        **keyword_args)
+        self.append(Queue.new(
           queue_name,
-          url: nil,
-          method: nil,
-          reservation_sid: nil,
-          post_work_activity_sid: nil,
-          **keyword_args)
-
-        queue = Queue.new(
-            queue_name,
-            url: url,
-            method: method,
-            reservation_sid: reservation_sid,
-            post_work_activity_sid: post_work_activity_sid,
-            **keyword_args
-        )
-
-        yield(queue) if block_given?
-
-        self.append(queue)
+          url: url,
+          method: method,
+          reservation_sid: reservation_sid,
+          post_work_activity_sid: post_work_activity_sid,
+          **keyword_args
+        ))
       end
 
       # Create a <Sim> element
@@ -574,11 +517,7 @@ module Twilio
       # == Returns:
       # A <Dial> element with a <Sim> child element
       def sim(sid, **keyword_args)
-        sim = Sim.new(sid, **keyword_args)
-
-        yield(sim) if block_given?
-
-        self.append(sim)
+        self.append(Sim.new(sid, **keyword_args))
       end
 
       # Create a <Sip> element
@@ -597,31 +536,26 @@ module Twilio
       # == Returns:
       # A <Dial> element with a <Sip> child element
       def sip(
+        uri,
+        username: nil,
+        password: nil,
+        url: nil,
+        method: nil,
+        status_callback: nil,
+        status_callback_event: nil,
+        status_callback_method: nil,
+        **keyword_args)
+        self.append(Sip.new(
           uri,
-          username: nil,
-          password: nil,
-          url: nil,
-          method: nil,
-          status_callback: nil,
-          status_callback_event: nil,
-          status_callback_method: nil,
-          **keyword_args)
-
-        sip = Sip.new(
-            uri,
-            username: username,
-            password: password,
-            url: url,
-            method: method,
-            status_callback: status_callback,
-            status_callback_event: status_callback_event,
-            status_callback_method: status_callback_method,
-            **keyword_args
-        )
-
-        yield(sip) if block_given?
-
-        self.append(sip)
+          username: username,
+          password: password,
+          url: url,
+          method: method,
+          status_callback: status_callback,
+          status_callback_event: status_callback_event,
+          status_callback_method: status_callback_method,
+          **keyword_args
+        ))
       end
     end
 
@@ -758,11 +692,7 @@ module Twilio
       # == Returns:
       # An <Enqueue> element with a <Task> child element
       def task(attributes, **keyword_args)
-        task = Task.new(attributes, **keyword_args)
-
-        yield(task) if block_given?
-
-        self.append(task)
+        self.append(Task.new(attributes, **keyword_args))
       end
     end
 
@@ -812,23 +742,18 @@ module Twilio
       # == Returns:
       # A <Gather> element with a <Say> child element
       def say(
+        body,
+        loop: nil,
+        language: nil,
+        voice: nil,
+        **keyword_args)
+        self.append(Say.new(
           body,
-          loop: nil,
-          language: nil,
-          voice: nil,
-          **keyword_args)
-
-        say = Say.new(
-            body,
-            loop: loop,
-            language: language,
-            voice: voice,
-            **keyword_args
-        )
-
-        yield(say) if block_given?
-
-        self.append(say)
+          loop: loop,
+          language: language,
+          voice: voice,
+          **keyword_args
+        ))
       end
 
       # Create a <Play> element
@@ -842,11 +767,12 @@ module Twilio
       # == Returns:
       # A <Gather> element with a <Play> child element
       def play(url: nil, loop: nil, digits: nil, **keyword_args)
-        play = Play.new(url: url, loop: loop, digits: digits, **keyword_args)
-
-        yield(play) if block_given?
-
-        self.append(play)
+        self.append(Play.new(
+          url: url,
+          loop: loop,
+          digits: digits,
+          **keyword_args
+        ))
       end
 
       # Create a <Pause> element
@@ -857,11 +783,7 @@ module Twilio
       # == Returns:
       # A <Gather> element with a <Pause> child element
       def pause(length: nil)
-        pause = Pause.new(length: length)
-
-        yield(pause) if block_given?
-
-        self.append(pause)
+        self.append(Pause.new(length: length))
       end
     end
 


### PR DESCRIPTION
The elements `<Hangup>`, `<Reject>`, `<Leave>`, `<Redirect>`, `<Body>`, `<Media>`, `<Say>`, `<Play>`, `<Pause>`, `<Task>`, `<Record>`, `<Sms>`, `<Client>`, `<Conference>`, `<Number>`, `<Queue>`, `<Sip>` and `<Sim>` cannot nest elements within them. So there's no need for them to react to a passed block.

Also, some four space indenting slipped in, returned to two spaces.