### PR TITLE
Configure params encoder only for Twilio requests

### DIFF
--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -12,13 +12,11 @@ module Twilio
         @proxy_pass = proxy_pass
         @ssl_ca_file = ssl_ca_file
         @adapter = Faraday.default_adapter
-
-        # Set default params encoder
-        Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
       end
 
       def request(host, port, method, url, params = {}, data = {}, headers = {}, auth = nil, timeout = nil)
         @connection = Faraday.new(url: host + ':' + port.to_s, ssl: { verify: true }) do |f|
+          f.options.params_encoder = Faraday::FlatParamsEncoder
           f.request :url_encoded
           f.adapter @adapter
           f.headers = headers


### PR DESCRIPTION
We saw a very strange issue when upgrading from 4.x to 5.x where suddenly unrelated HTTP requests had nested params encoded incorrectly. It looks like this is because of [this line](https://github.com/twilio/twilio-ruby/blob/cc8880bf949e03882004bd72854d31c0bc1a41f1/lib/twilio-ruby/http/http_client.rb#L17), where the global default params encoder for all Faraday instances is changed from `Faraday::NestedParamsEncoder` to `Faraday::FlatParamsEncoder`.

This sets the `env.params_encoder` in the Faraday client set up just for Twilio requests, so other API clients are not affected.