### PR TITLE
Corrects to_xml in TwiML generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ section of the wiki.
 
 ## Getting Started With TwiML
 
-TwiML support is based on the [Builder][builder] library. You can construct a
-TwiML response like this:
+You can construct a TwiML response like this:
 
 ```ruby
 require 'twilio-ruby'
@@ -161,7 +160,6 @@ implementations:
 - Ruby 2.0.0
 
 [capability]: https://github.com/twilio/twilio-ruby/wiki/Capability
-[builder]: http://builder.rubyforge.org/
 [examples]: https://github.com/twilio/twilio-ruby/blob/master/examples
 [documentation]: http://twilio.github.io/twilio-ruby
 [wiki]: https://github.com/twilio/twilio-ruby/wiki

--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -11,8 +11,6 @@ module Twilio
       attr_accessor :name
       attr_accessor :indent
 
-      alias to_xml to_s
-
       def initialize(indent: false, **keyword_args)
         @name = self.class.name.split('::').last
         @indent = indent
@@ -37,6 +35,7 @@ module Twilio
         return ('<?xml version="1.0" encoding="UTF-8"?>' + xml) if xml_declaration
         xml
       end
+      alias to_xml to_s
 
       def xml
         # create XML element

--- a/spec/twiml/messaging_response_spec.rb
+++ b/spec/twiml/messaging_response_spec.rb
@@ -7,6 +7,11 @@ describe Twilio::TwiML::MessagingResponse do
       expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response/>')
     end
 
+    it 'should allow using to_xml instead of to_s' do
+      r = Twilio::TwiML::MessagingResponse.new
+      expect(r.to_xml).to eq('<?xml version="1.0" encoding="UTF-8"?><Response/>')
+    end
+
     it 'should allow populated response' do
       r = Twilio::TwiML::MessagingResponse.new
       r.message(body: 'Hello')

--- a/spec/twiml/voice_response_spec.rb
+++ b/spec/twiml/voice_response_spec.rb
@@ -7,6 +7,11 @@ describe Twilio::TwiML::VoiceResponse do
       expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response/>')
     end
 
+    it 'should allow using to_xml instead of to_s' do
+      r = Twilio::TwiML::VoiceResponse.new
+      expect(r.to_xml).to eq('<?xml version="1.0" encoding="UTF-8"?><Response/>')
+    end
+
     it 'should allow populated response' do
       r = Twilio::TwiML::VoiceResponse.new
       r.hangup


### PR DESCRIPTION
`Twilio::TwiML::TwiML#to_xml` was being aliased to `to_s` before `to_s` was defined so took on the old definition.

This PR adds tests for using `to_xml` and fixes the aliasing. It also removes the reference to [builder](https://rubygems.org/gems/builder/) in the README.