### PR TITLE
to_s should only be defined in one spot for JWTs.

### DIFF
--- a/lib/twilio-ruby/jwt/access_token.rb
+++ b/lib/twilio-ruby/jwt/access_token.rb
@@ -50,10 +50,6 @@ module Twilio
         @grants.push(grant)
       end
 
-      def to_s
-        to_jwt
-      end
-
       protected
 
       def _generate_payload

--- a/lib/twilio-ruby/jwt/client_capability.rb
+++ b/lib/twilio-ruby/jwt/client_capability.rb
@@ -12,8 +12,6 @@ module Twilio
                     :client_name,
                     :scopes
 
-      alias to_s to_jwt
-
       def initialize(account_sid, auth_token, scopes: [], nbf: nil, ttl: 3600, valid_until: nil)
         super(secret_key: auth_token, issuer: account_sid, nbf: nbf, ttl: ttl, valid_until: valid_until)
         @account_sid = account_sid

--- a/lib/twilio-ruby/jwt/jwt.rb
+++ b/lib/twilio-ruby/jwt/jwt.rb
@@ -38,13 +38,14 @@ module Twilio
         payload[:nbf] = @nbf || Time.now.to_i
         payload[:exp] = @valid_until.nil? ? Time.now.to_i + @ttl : @valid_until
         payload[:sub] = @subject unless @subject.nil?
-        
+
         payload
       end
 
       def to_jwt
         ::JWT.encode payload, @secret_key, @algorithm, headers
       end
+      alias to_s to_jwt
     end
   end
 end

--- a/lib/twilio-ruby/jwt/task_router.rb
+++ b/lib/twilio-ruby/jwt/task_router.rb
@@ -20,10 +20,6 @@ module Twilio
         @policies.push(policy)
       end
 
-      def to_s
-        to_jwt
-      end
-
       protected
 
       def _generate_payload


### PR DESCRIPTION
As discovered in #318, `BaseJWT` defines `to_jwt` but all the subclasses individually define or alias `to_s` to `to_jwt`. This PR tidies that up and aliases `to_s` to `to_jwt` in the base class.