### PR TITLE
Allow libxml 2 or 3 [Fixes #315]

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['README.md', 'LICENSE.md']
   spec.rdoc_options = ['--line-numbers', '--inline-source', '--title', 'twilio-ruby', '--main', 'README.md']
 
-  spec.add_dependency('libxml-ruby', '3.0.0')
+  spec.add_dependency('libxml-ruby', '>= 2.0', '< 4.0')
   spec.add_dependency('jwt', '~> 1.5')
   spec.add_dependency('faraday', '~>0.9')
   spec.add_dependency('jruby-openssl') if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
twilio-ruby works with either libxml version 2 or 3.
libxml2 is common enough in other gems that allowing it here will reduce gem conflicts