### PR TITLE
Support API credentials in Twilio.configure

### DIFF
--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -43,7 +43,7 @@ end
 module Twilio
   extend SingleForwardable
 
-  def_delegators :configuration, :account_sid, :auth_token
+  def_delegators :configuration, :account_sid, :auth_token, :api_sid, :api_secret
 
   ##
   # Pre-configure with account SID and auth token so that you don't need to

--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -14,10 +14,17 @@ module Twilio
       ##
       # Initializes the Twilio Client
       def initialize(username=nil, password=nil, account_sid=nil, region=nil, http_client=Twilio::HTTP::Client.new)
-        @username = username || Twilio.account_sid
-        @password = password || Twilio.auth_token
+        # Prefer API authentication if set in configuration
+        if Twilio.api_sid
+          @username = username || Twilio.api_sid
+          @password = password || Twilio.api_secret
+          @account_sid = account_sid || Twilio.account_sid
+        else
+          @username = username || Twilio.account_sid
+          @password = password || Twilio.auth_token
+          @account_sid = account_sid || @username
+        end
         @region = region
-        @account_sid = account_sid || @username
         @auth_token = @password
         @auth = [@username, @password]
         @http_client = http_client

--- a/lib/twilio-ruby/util/configuration.rb
+++ b/lib/twilio-ruby/util/configuration.rb
@@ -1,7 +1,7 @@
 module Twilio
   module Util
     class Configuration
-      attr_accessor :account_sid, :auth_token
+      attr_accessor :account_sid, :auth_token, :api_sid, :api_secret
     end
   end
 end

--- a/spec/twilio_spec.rb
+++ b/spec/twilio_spec.rb
@@ -12,4 +12,17 @@ describe Twilio do
     expect(Twilio.account_sid).to eq('someSid')
     expect(Twilio.auth_token).to eq('someToken')
   end
+
+  it 'should set the account sid and api credentials with a config block' do
+    Twilio.configure do |config|
+      config.account_sid = 'someSid'
+      config.api_sid = 'someApiSid'
+      config.api_secret = 'someApiSecret'
+    end
+
+    expect(Twilio.account_sid).to eq('someSid')
+    expect(Twilio.auth_token).to be_nil
+    expect(Twilio.api_sid).to eq('someApiSid')
+    expect(Twilio.api_secret).to eq('someApiSecret')
+  end
 end

--- a/spec/util/configuration_spec.rb
+++ b/spec/util/configuration_spec.rb
@@ -12,4 +12,16 @@ describe Twilio::Util::Configuration do
     config.auth_token = 'someToken'
     expect(config.auth_token).to eq('someToken')
   end
+
+  it 'should have an api sid attribute' do
+    config = Twilio::Util::Configuration.new
+    config.api_sid = 'someApiSid'
+    expect(config.api_sid).to eq('someApiSid')
+  end
+
+  it 'should have an api secret attribute' do
+    config = Twilio::Util::Configuration.new
+    config.api_secret = 'someApiSecret'
+    expect(config.api_secret).to eq('someApiSecret')
+  end
 end


### PR DESCRIPTION
[Twilio docs state](https://www.twilio.com/docs/api/rest/request#credentials) that using AccountSid and AuthToken can be replaced with API credentials to authenticate into the platform. Some developers, including myself, thought that the API keys could be drop-in replacements for the Twilio.configure block, which is untrue.

I was attempting to do the following, mimicking the spirit of the referenced documentation, and getting the following result:

```ruby
Twilio.configure do |config|
  config.account_sid = 'someApiSid'
  config.auth_token = 'someApiSecret'
end

Twilio::REST::Client.new().messages.create(...)
# => Twilio::REST::RestError: Unable to create record: AccountSid someApiSid is invalid 
```

This PR maintains backwards compatibility but allows for developers to universally configure the Twilio client to use their API credentials for authentication and set the appropriate AccountSid context for Message creation and other calls.

Now a developer can use the existing style:

```ruby
Twilio.configure do |config|
  config.account_sid = 'someSid'
  config.auth_token = 'someToken'
end

Twilio::REST::Client.new().messages.create(...)
# => success
```

Or chose to configure with API keys so they'll authenticate with that instead

```ruby
Twilio.configure do |config|
  config.account_sid = 'someSid'
  config.api_sid = 'someApiSid'
  config.api_secret = 'someApiSecret'
end

Twilio::REST::Client.new().messages.create(...)
# => success
```