### PR TITLE
Allow configuring timeout globally on HttpClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 bundler_args: --without development
+
 rvm:
   - ruby-head
   - 2.4.0
@@ -9,5 +10,11 @@ rvm:
   - 2.2.0
   - 2.1
   - 2.0.0
+
 matrix:
   fast_finish: true
+
+before_install:
+  # Bundler on Travis may be too out of date
+  # Update bundler to a recent version.
+  - gem install bundler

--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -4,14 +4,16 @@ module Twilio
   module HTTP
     class Client
       attr_accessor :adapter
-      attr_reader :last_response, :last_request
+      attr_reader :timeout, :last_response, :last_request
 
-      def initialize(proxy_addr = nil, proxy_port = nil, proxy_user = nil, proxy_pass = nil, ssl_ca_file = nil)
+      def initialize(proxy_addr = nil, proxy_port = nil, proxy_user = nil, proxy_pass = nil, ssl_ca_file = nil,
+                     timeout: nil)
         @proxy_addr = proxy_addr
         @proxy_port = proxy_port
         @proxy_user = proxy_user
         @proxy_pass = proxy_pass
         @ssl_ca_file = ssl_ca_file
+        @timeout = timeout
         @adapter = Faraday.default_adapter
       end
 
@@ -25,8 +27,8 @@ module Twilio
           if @proxy_addr
             f.proxy '#{@proxy_user}:#{@proxy_pass}@#{@proxy_addr}:#{@proxy_port}'
           end
-          f.options.open_timeout = request.timeout
-          f.options.timeout = request.timeout
+          f.options.open_timeout = request.timeout || @timeout
+          f.options.timeout = request.timeout || @timeout
         end
 
         @last_request = request

--- a/spec/http/http_client_spec.rb
+++ b/spec/http/http_client_spec.rb
@@ -6,6 +6,34 @@ describe Twilio::HTTP::Client do
     @client = Twilio::HTTP::Client.new
   end
 
+  it 'should allow setting a global timeout' do
+    @client = Twilio::HTTP::Client.new(timeout: 10)
+    @connection = Faraday::Connection.new
+
+    expect(Faraday).to receive(:new).and_yield(@connection).and_return(@connection)
+    allow_any_instance_of(Faraday::Connection).to receive(:send).and_return(double('response', status: 301, body: {}))
+
+    @client.request('host', 'port', 'GET', 'url', nil, nil, {}, ['a', 'b'])
+
+    expect(@client.timeout).to eq(10)
+    expect(@connection.options.open_timeout).to eq(10)
+    expect(@connection.options.timeout).to eq(10)
+  end
+
+  it 'should allow overriding timeout per request' do
+    @client = Twilio::HTTP::Client.new(timeout: 10)
+    @connection = Faraday::Connection.new
+
+    expect(Faraday).to receive(:new).and_yield(@connection).and_return(@connection)
+    allow_any_instance_of(Faraday::Connection).to receive(:send).and_return(double('response', status: 301, body: {}))
+
+    @client.request('host', 'port', 'GET', 'url', nil, nil, {}, ['a', 'b'], 20)
+
+    expect(@client.timeout).to eq(10)
+    expect(@connection.options.open_timeout).to eq(20)
+    expect(@connection.options.timeout).to eq(20)
+  end
+
   it 'should contain a last response' do
     expect(Faraday).to receive(:new).and_return(Faraday::Connection.new)
     allow_any_instance_of(Faraday::Connection).to receive(:send).and_return(double('response', status: 301, body: {}))


### PR DESCRIPTION
HttpClient now accepts a `timeout` keyword argument which will be used when making requests to twilio. 

Example of initializing a rest client with a custom timeout:
```ruby
http_client = Twilio::HTTP::Client.new(timeout: 10)
client = Twilio::REST::Client.new('AC123', '<auth>', nil, nil, http_client)
```

Fix for https://github.com/twilio/twilio-ruby/issues/306