### PR TITLE
Add after_request callback to be able to inspect request body and headers.

### DIFF
--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -37,6 +37,8 @@ module Twilio
                                     request.url,
                                     request.method == 'GET' ? request.params : request.data)
 
+        after_request(response)
+
         if response.body && !response.body.empty?
           object = response.body
         elsif response.status == 400
@@ -52,6 +54,11 @@ module Twilio
       def request(host, port, method, url, params = {}, data = {}, headers = {}, auth = nil, timeout = nil)
         request = Twilio::Request.new(host, port, method, url, params, data, headers, auth, timeout)
         _request(request)
+      end
+
+      private
+
+      def after_request(response)
       end
     end
   end

--- a/spec/http/http_client_spec.rb
+++ b/spec/http/http_client_spec.rb
@@ -118,4 +118,14 @@ describe Twilio::HTTP::Client do
     expect { @client.request('host', 'port', 'GET', 'url', nil, nil, {}, ['a', 'b']) }.to raise_exception(Faraday::ConnectionFailed)
     expect(@client.last_response).to be_nil
   end
+
+  it '#after_request callback is called after request' do
+    response = double('response', status: 301, body: {})
+
+    expect(Faraday).to receive(:new).and_return(Faraday::Connection.new)
+    allow_any_instance_of(Faraday::Connection).to receive(:send).and_return(response)
+    expect(@client).to receive(:after_request).with(response)
+
+    @client.request('host', 'port', 'GET', 'url', nil, nil, {}, ['a', 'b'])
+  end
 end


### PR DESCRIPTION
👋 👋 👋 

With this change it would be really easy to get access to full response from Twilio. Use case that I'm trying to solve is accessing [Twilio Telemetry](https://www.twilio.com/engineering/2015/09/28/twilio-request-telemetry) headers to be able to better understand what is happening when sending requests to Twilio.

```ruby
class CustomClient < Twilio::HTTP::Client

  private

  def after_request(response)
    puts response.inspect
  end
end

http_client = CustomClient.new
client = Twilio::REST::Client.new(sid, auth, nil, nil, http_client)
```