### PR TITLE
Decompose version for easier major version checking.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,10 +14,10 @@ task :authors do
 end
 
 task :deploy, [:version] => [:spec, :authors] do |t, args|
-  current_version = Twilio::VERSION
+  current_version = Twilio::VERSION::STRING
 
   if args.version.nil?
-    version = Twilio::VERSION
+    version = Twilio::VERSION::STRING
     version_parts = version.split('.')
     increment = version_parts.pop
     increment_prefix = increment.split(/\d/)[0]

--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -9,7 +9,7 @@ require 'jwt'
 require 'time'
 require 'json'
 
-require 'twilio-ruby/version' unless defined?(Twilio::VERSION)
+require 'twilio-ruby/version' unless defined?(Twilio::VERSION::STRING)
 require 'rack/twilio_webhook_authentication'
 
 require 'twilio-ruby/util'

--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -48,7 +48,7 @@ module Twilio
       def request(host, port, method, uri, params={}, data={}, headers={}, auth=nil, timeout=nil)
         auth ||= @auth
 
-        headers['User-Agent'] = "twilio-ruby/#{Twilio::VERSION}" +
+        headers['User-Agent'] = "twilio-ruby/#{Twilio::VERSION::STRING}" +
                                 " (#{RUBY_ENGINE}/#{RUBY_PLATFORM}" +
                                 " #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL})"
         headers['Accept-Charset'] = 'utf-8'

--- a/lib/twilio-ruby/version.rb
+++ b/lib/twilio-ruby/version.rb
@@ -1,3 +1,9 @@
 module Twilio
-    VERSION = '5.4.2'
+  module VERSION
+    MAJOR = 5
+    MINOR = 4
+    TINY  = 2
+
+    STRING = [MAJOR, MINOR, TINY].compact.join(".")
+  end
 end

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -6,7 +6,7 @@ require 'twilio-ruby/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'twilio-ruby'
-  spec.version       = Twilio::VERSION
+  spec.version       = Twilio::VERSION::STRING
   spec.authors	     = ['Twilio API Team']
   spec.summary       = 'A simple library for communicating with the Twilio REST API, '\
                        'building TwiML, and generating Twilio JWT Capability Tokens'


### PR DESCRIPTION
Decompose version so that it's easier to check major version when upgrading gem.

```ruby
if Twilio::VERSION::MAJOR >= 5
  # use new API
else
  #use old API
end
```