### PR TITLE
Fixed example code

### DIFF
--- a/examples/print_call_log.rb
+++ b/examples/print_call_log.rb
@@ -12,7 +12,7 @@ auth_token = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
 # set up a client
 client = Twilio::REST::Client.new(account_sid, auth_token)
 
-calls = client.calls.page
+calls = client.calls.list
 
 loop do
   calls.each do |call|


### PR DESCRIPTION
This example code is not working.
The following error message appears.

```rb
Traceback (most recent call last):
print_call_log.rb:15:in `<main>': undefined method `page' for #<Twilio::REST::Calls:0x00007fd59888e210> (NoMethodError)
```

Change a caliing method page() to list().
It works!