### PR TITLE
Fix ClientCapability appParams

### DIFF
--- a/lib/twilio-ruby/jwt/client_capability.rb
+++ b/lib/twilio-ruby/jwt/client_capability.rb
@@ -68,7 +68,7 @@ module Twilio
             client_name = "clientName=#{CGI.escape(@client_name)}"
           end
           unless @params.empty?
-            params = 'appParams=' + @params.map { |k, v| CGI.escape("#{k}=#{v}") }.join('&')
+            params = 'appParams=' + @params.map { |k, v| CGI.escape("#{k}=#{v}") }.join('%26')
           end
 
           suffix = [application_sid, client_name, params].compact.join('&')


### PR DESCRIPTION
In `appParams` the `&` separator should be URL-encoded.