### PR TITLE
Fixes xml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ in-line code documentation here in the library.
 To install using [Bundler][bundler] grab the latest stable version:
 
 ```ruby
-gem 'twilio-ruby', '~> 5.5.0'
+gem 'twilio-ruby', '~> 5.5.1'
 ```
 
 To manually install `twilio-ruby` via [Rubygems][rubygems] simply gem install:
 
 ```bash
-gem install twilio-ruby -v 5.5.0
+gem install twilio-ruby -v 5.5.1
 ```
 
 To build and install the development branch yourself from the latest source:

--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -34,11 +34,14 @@ module Twilio
         end
 
         def to_s(xml_declaration = true)
-          opts = { encoding: 'UTF-8', indent: 0 }
+          save_opts = Nokogiri::XML::Node::SaveOptions::DEFAULT_XML
+          if !xml_declaration
+            save_opts = save_opts | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
+          end
+          opts = { encoding: 'UTF-8', indent: 0, save_with: save_opts }
           document = Nokogiri::XML::Document.new
-          xml = self.xml(document).to_xml(opts).gsub(/\n/, '')
-          return ('<?xml version="1.0" encoding="UTF-8"?>' + xml) if xml_declaration
-          xml
+          document << self.xml(document)
+          document.to_xml(opts)
         end
 
         def xml(document)

--- a/lib/twilio-ruby/version.rb
+++ b/lib/twilio-ruby/version.rb
@@ -1,3 +1,3 @@
 module Twilio
-    VERSION = '5.5.0'
+    VERSION = '5.5.1'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,9 @@ end
 def auth_token
   ENV['AUTH_TOKEN']
 end
+
+def parse(twiml_response)
+  Nokogiri::XML::Document.parse(twiml_response.to_s) do |options|
+    options.noblanks
+  end
+end

--- a/spec/twiml/messaging_response_spec.rb
+++ b/spec/twiml/messaging_response_spec.rb
@@ -151,6 +151,22 @@ describe Twilio::TwiML::MessagingResponse do
       doc = parse(response)
       expect(doc).to be_equivalent_to(expected_doc).respecting_element_order
     end
+
+    it 'should allow and preserve new lines in messages' do
+      expected_doc = parse <<-XML
+        <Response>
+          <Message>Hello
+World
+          </Message>
+        </Response>
+      XML
+
+      response = Twilio::TwiML::MessagingResponse.new
+      response.message(body: "Hello\nWorld")
+
+      doc = parse(response)
+      expect(doc).to be_equivalent_to(expected_doc).respecting_element_order
+    end
   end
 
   context 'Testing Redirect' do

--- a/spec/twiml/messaging_response_spec.rb
+++ b/spec/twiml/messaging_response_spec.rb
@@ -3,93 +3,149 @@ require 'spec_helper'
 describe Twilio::TwiML::MessagingResponse do
   context 'Testing Response' do
     it 'should allow empty response' do
-      r = Twilio::TwiML::MessagingResponse.new
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response/>')
+      response = Twilio::TwiML::MessagingResponse.new.to_s
+      doc = parse(response)
+      expect(doc.children.length).to eq(1)
+      expect(doc.children.first.name).to eq('Response')
+      expect(doc.children.first.content).to be_empty
     end
 
     it 'should allow using to_xml instead of to_s' do
-      r = Twilio::TwiML::MessagingResponse.new
-      expect(r.to_xml).to eq('<?xml version="1.0" encoding="UTF-8"?><Response/>')
+      response = Twilio::TwiML::MessagingResponse.new.to_xml
+      doc = parse(response)
+      expect(doc.children.length).to eq(1)
+      expect(doc.children.first.name).to eq('Response')
+      expect(doc.children.first.content).to be_empty
     end
 
     it 'should allow populated response' do
-      r = Twilio::TwiML::MessagingResponse.new
-      r.message(body: 'Hello')
-      r.redirect('example.com')
-
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Message>Hello</Message><Redirect>example.com</Redirect></Response>')
+      response = Twilio::TwiML::MessagingResponse.new
+      response.message(body: 'Hello')
+      response.redirect('example.com')
+      doc = parse(response)
+      response_element = doc.xpath('/Response')
+      children = response_element.children
+      expect(children.length).to eq(2)
+      expect(children[0].name).to eq('Message')
+      expect(children[0].content).to eq('Hello')
+      expect(children[1].name).to eq('Redirect')
+      expect(children[1].content).to eq('example.com')
     end
 
     it 'should allow chaining' do
-      r = Twilio::TwiML::MessagingResponse.new.message(body: 'Hello').redirect('example.com')
-
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Message>Hello</Message><Redirect>example.com</Redirect></Response>')
+      response = Twilio::TwiML::MessagingResponse.new.message(body: 'Hello').redirect('example.com')
+      doc = parse(response)
+      response_element = doc.xpath('/Response')
+      children = response_element.children
+      expect(children.length).to eq(2)
+      expect(children[0].name).to eq('Message')
+      expect(children[0].content).to eq('Hello')
+      expect(children[1].name).to eq('Redirect')
+      expect(children[1].content).to eq('example.com')
     end
 
     it 'should allow nesting' do
-      r = Twilio::TwiML::MessagingResponse.new
-      r.message(body: 'Hello') do |m|
-        m.media('foobar')
+      response = Twilio::TwiML::MessagingResponse.new
+      response.message(body: 'Hello') do |message|
+        message.media('foobar')
       end
-
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Message>Hello<Media>foobar</Media></Message></Response>')
+      doc = parse(response)
+      response_element = doc.xpath('/Response')
+      children = response_element.children
+      expect(children.length).to eq(1)
+      message = doc.xpath('/Response/Message')
+      expect(message.children[0].content).to eq('Hello')
+      media = message.children[1]
+      expect(media.name).to eq('Media')
+      expect(media.content).to eq('foobar')
     end
 
     it 'should allow nesting and chaining' do
-      r = Twilio::TwiML::MessagingResponse.new
-      r.message(body: 'Hello') do |m|
-        m.media('foobar')
+      response = Twilio::TwiML::MessagingResponse.new
+      response.message(body: 'Hello') do |message|
+        message.media('foobar')
       end
 
-      r.redirect('example.com')
+      response.redirect('example.com')
 
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Message>Hello<Media>foobar</Media></Message><Redirect>example.com</Redirect></Response>')
+      doc = parse(response)
+      response_element = doc.xpath('/Response')
+      children = response_element.children
+      expect(children.length).to eq(2)
+      message = doc.xpath('/Response/Message')
+      expect(message.children[0].content).to eq('Hello')
+      media = message.children[1]
+      expect(media.name).to eq('Media')
+      expect(media.content).to eq('foobar')
+      redirect = doc.xpath('/Response/Redirect').first
+      expect(redirect.content).to eq('example.com')
     end
 
     it 'should allow nesting from the initializer' do
-      response = Twilio::TwiML::MessagingResponse.new do |r|
-        r.message(body: 'Hello')
-        r.redirect('example.com')
+      response = Twilio::TwiML::MessagingResponse.new do |res|
+        res.message(body: 'Hello')
+        res.redirect('example.com')
       end
-      expect(response.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Message>Hello</Message><Redirect>example.com</Redirect></Response>')
+      doc = parse(response)
+      response_element = doc.xpath('/Response')
+      expect(response_element.children.length).to eq(2)
+      message = response_element.children.first
+      redirect = response_element.children[1]
+      expect(message.name).to eq('Message')
+      expect(message.content).to eq('Hello')
+      expect(redirect.name).to eq('Redirect')
+      expect(redirect.content).to eq('example.com')
     end
   end
 
   context 'Testing Message' do
     it 'should allow a body' do
-      r = Twilio::TwiML::MessagingResponse.new
-      r.message(body: 'Hello')
-
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Message>Hello</Message></Response>')
+      response = Twilio::TwiML::MessagingResponse.new
+      response.message(body: 'Hello')
+      doc = parse(response)
+      message = doc.xpath('/Response/Message').first
+      expect(message.content).to eq('Hello')
     end
 
     it 'should allow appending Body' do
-      b = Twilio::TwiML::Body.new('Hello World')
+      body = Twilio::TwiML::Body.new('Hello World')
+      message = Twilio::TwiML::Message.new
 
-      r = Twilio::TwiML::MessagingResponse.new
-      r.append(b)
+      response = Twilio::TwiML::MessagingResponse.new
+      message.append(body)
+      response.append(message)
 
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Body>Hello World</Body></Response>')
+      doc = parse(response)
+      body_elem = doc.xpath('/Response/Message/Body').first
+      expect(body_elem.content).to eq('Hello World')
     end
 
     it 'should allow appending Body and Media' do
-      b = Twilio::TwiML::Body.new('Hello World')
-      m = Twilio::TwiML::Media.new('hey.jpg')
+      body = Twilio::TwiML::Body.new('Hello World')
+      media = Twilio::TwiML::Media.new('hey.jpg')
+      message = Twilio::TwiML::Message.new
 
-      r = Twilio::TwiML::MessagingResponse.new
-      r.append(b)
-      r.append(m)
+      response = Twilio::TwiML::MessagingResponse.new
+      message.append(body)
+      message.append(media)
+      response.append(message)
 
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Body>Hello World</Body><Media>hey.jpg</Media></Response>')
+      doc = parse(response)
+      body_elem = doc.xpath('/Response/Message/Body').first
+      message_elem = doc.xpath('/Response/Message/Media').first
+      expect(body_elem.content).to eq('Hello World')
+      expect(message_elem.content).to eq('hey.jpg')
     end
   end
 
   context 'Testing Redirect' do
     it 'should allow MessagingResponse.redirect' do
-      r = Twilio::TwiML::MessagingResponse.new
-      r.redirect('example.com')
+      response = Twilio::TwiML::MessagingResponse.new
+      response.redirect('example.com')
 
-      expect(r.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><Response><Redirect>example.com</Redirect></Response>')
+      doc = parse(response)
+      redirect = doc.xpath('/Response/Redirect').first
+      expect(redirect.content).to eq('example.com')
     end
   end
 end


### PR DESCRIPTION
This leads to XML that has line breaks after each element, which wasn't present before, but doesn't break anything in terms of the expected output. This follows #382 (well, it includes all of #382, but should be separately reviewed), which updated the tests to not worry about insignificant whitespace. It should also be written into Yoyodyne since `twiml.rb` is generated.

The purpose of this PR is to properly use all of Nokogiri's features to generate the XML, including the header, and fixes what seems like an inconsistency, in which the XML is generated from a `Node` instead of the whole `Document`.