### PR TITLE
Add incoming.allow to AccessToken VoiceGrant

### DIFF
--- a/lib/twilio-ruby/jwt/access_token.rb
+++ b/lib/twilio-ruby/jwt/access_token.rb
@@ -156,12 +156,7 @@ module Twilio
 
         def _generate_payload
           payload = {}
-
-          if incoming_allow == true
-            incoming = {}
-            incoming[:allow] = true
-            payload[:incoming] = incoming
-          end
+          payload[:incoming] = { allow: true } if incoming_allow == true
 
           if outgoing_application_sid
             outgoing = {}

--- a/lib/twilio-ruby/jwt/access_token.rb
+++ b/lib/twilio-ruby/jwt/access_token.rb
@@ -144,7 +144,8 @@ module Twilio
 
       class VoiceGrant
         include AccessTokenGrant
-        attr_accessor :outgoing_application_sid,
+        attr_accessor :incoming_allow,
+                      :outgoing_application_sid,
                       :outgoing_application_params,
                       :push_credential_sid,
                       :endpoint_id
@@ -155,6 +156,12 @@ module Twilio
 
         def _generate_payload
           payload = {}
+
+          if incoming_allow == true
+            incoming = {}
+            incoming[:allow] = true
+            payload[:incoming] = incoming
+          end
 
           if outgoing_application_sid
             outgoing = {}

--- a/spec/jwt/access_token_spec.rb
+++ b/spec/jwt/access_token_spec.rb
@@ -75,6 +75,7 @@ describe Twilio::JWT::AccessToken do
 
       it 'Voice grant' do
         voice_grant = Twilio::JWT::AccessToken::VoiceGrant.new
+        voice_grant.incoming_allow = true
         voice_grant.outgoing_application_sid = 'AP123'
         voice_grant.outgoing_application_params = {:foo => 'bar'}
         voice_grant.push_credential_sid = 'PC123'
@@ -82,6 +83,7 @@ describe Twilio::JWT::AccessToken do
         @scat.add_grant(voice_grant)
         payload, _ = JWT.decode @scat.to_s, 'secret'
         expect(payload['grants'].count).to eq(1)
+        expect(payload['grants']['voice']['incoming']['allow']).to eq(true)
         expect(payload['grants']['voice']['outgoing']['application_sid']).to eq('AP123')
         expect(payload['grants']['voice']['outgoing']['params']['foo']).to eq('bar')
         expect(payload['grants']['voice']['push_credential_sid']).to eq('PC123')


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/CLIENT-4492

To support JS Clients per this spec:
https://paper.dropbox.com/doc/Proposal-FPA-Token-Format-for-Programmable-Voice-SDKs-xhdFHD6N3aPW9GRp4dXNX