### PR TITLE
Improves error message for Twilio::REST::RestError.

### DIFF
--- a/lib/twilio-ruby/framework/error.rb
+++ b/lib/twilio-ruby/framework/error.rb
@@ -14,16 +14,30 @@ module Twilio
     end
 
     class RestError < TwilioError
-      attr_reader :message, :code, :status_code
+      attr_reader :message, :response, :code, :status_code, :detail, :more_info, :error_message
 
-      def initialize(message, code, status_code)
-        @message = message
-        @code = code
-        @status_code = status_code
+      def initialize(message, response)
+        @status_code = response.status_code
+        @code = response.body.fetch('code', @status_code)
+        @detail = response.body.fetch('detail', nil)
+        @error_message = response.body.fetch('message', nil)
+        @more_info = response.body.fetch('more_info', nil)
+        @message = format_message(message)
+        @response = response
       end
 
       def to_s
-        "[HTTP #{status_code}] #{code} : #{message}"
+        message
+      end
+
+      private
+
+      def format_message(initial_message)
+        message = "[HTTP #{status_code}] #{code} : #{initial_message}"
+        message += "\n#{error_message}" if error_message
+        message += "\n#{detail}" if detail
+        message += "\n#{more_info}" if more_info
+        message += "\n\n"
       end
     end
 

--- a/lib/twilio-ruby/framework/version.rb
+++ b/lib/twilio-ruby/framework/version.rb
@@ -52,16 +52,7 @@ module Twilio
       end
 
       def exception(response, header)
-        message = header
-        code = response.status_code
-
-        if response.body.key?('message')
-          message += ": #{response.body['message']}"
-        end
-
-        code = response.body['code'] if response.body.key?('code')
-
-        Twilio::REST::RestError.new(message, code, response.status_code)
+        Twilio::REST::RestError.new(header, response)
       end
 
       def fetch(method, uri, params = {}, data = {}, headers = {}, auth = nil, timeout = nil)


### PR DESCRIPTION
Based on feedback from https://betta.io/blog/2018/03/30/graceful-errors-in-ruby-sdks/.

With the following code:

```ruby
require './lib/twilio-ruby'

account_sid = ENV['TWILIO_ACCOUNT_SID']
auth_token = ENV['TWILIO_AUTH_TOKEN']

client = Twilio::REST::Client.new account_sid, auth_token
client.messages.create
```

the error message before looks like:

```
/Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/framework/version.rb:157:in `create': Unable to create record: A 'From' phone number is required. (Twilio::REST::RestError)
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:71:in `create'
	from test.rb:23:in `<main>'
```

But with this change, looks like:

```
/Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/framework/version.rb:148:in `create': [HTTP 400] 21603 : Unable to create record (Twilio::REST::RestError)
A 'From' phone number is required.
https://www.twilio.com/docs/errors/21603

	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:71:in `create'
	from test.rb:23:in `<main>'
```