### PR TITLE
Uses Twilio::REST::RestError when a page fails to load

### DIFF
--- a/lib/twilio-ruby/framework/error.rb
+++ b/lib/twilio-ruby/framework/error.rb
@@ -1,15 +1,11 @@
 module Twilio
   module REST
     class TwilioError < StandardError
-      attr_reader :message, :body
 
-      def initialize(message, body = nil)
-        @message = message
-        @body = body
-      end
-
-      def to_s
-        "#{@message}: #{@body || 'no body'}"
+      # @deprecated all errors that have a body are now 'Twilio::RestError's
+      def body
+        warn "'Twilio::REST::TwilioError#body' has been deprecated. No 'TwilioError' objects are raised with a body."
+        nil
       end
     end
 
@@ -24,6 +20,12 @@ module Twilio
         @more_info = response.body.fetch('more_info', nil)
         @message = format_message(message)
         @response = response
+      end
+
+      # @deprecated use #response instead
+      def body
+        warn "This error used to be a 'Twilio::REST::TwilioError' but is now a 'Twilio::REST::RestError'. Please use #response instead of #body."
+        @response
       end
 
       def to_s

--- a/lib/twilio-ruby/framework/page.rb
+++ b/lib/twilio-ruby/framework/page.rb
@@ -29,7 +29,7 @@ module Twilio
 
       def process_response(response)
         if response.status_code != 200
-          raise Twilio::REST::TwilioError.new('Unable to fetch page', response)
+          raise Twilio::REST::RestError.new('Unable to fetch page', response)
         end
 
         response.body


### PR DESCRIPTION
This follows on from #391.

With the following code:

```ruby
require './lib/twilio-ruby'

# We'll use a valid SID
account_sid = ENV['TWILIO_ACCOUNT_SID']
# But we'll use an invalid auth token
client = Twilio::REST::Client.new account_sid, "not_my_auth_token"
client.api.account.messages.list
```

the error message looks like:

```
/Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/framework/page.rb:32:in `process_response': Unable to fetch page (Twilio::REST::TwilioError)
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/framework/page.rb:22:in `initialize'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:212:in `initialize'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:181:in `new'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:181:in `page'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:127:in `stream'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:97:in `list'
	from test.rb:11:in `<main>'
```

But with this change looks like:

```
/Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/framework/page.rb:32:in `process_response': [HTTP 401] 20003 : Unable to fetch page (Twilio::REST::RestError)
Authenticate
Your AccountSid or AuthToken was incorrect.
https://www.twilio.com/docs/errors/20003

	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/framework/page.rb:22:in `initialize'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:212:in `initialize'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:181:in `new'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:181:in `page'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:127:in `stream'
	from /Users/pnash/projects/ruby-projects/twilio-ruby/lib/twilio-ruby/rest/api/v2010/account/message.rb:97:in `list'
	from test.rb:11:in `<main>'`
```

This relies on the work done in #391 as it really just uses the `Twilio::REST::RestError` in place of the `Twilio::REST::TwilioError` when it is raised in response to a non 200 status code in `Twilio::REST::Page#process_response`.

The rest of the work just ensures that anyone using the now defunct `body` method in the `Twilio::REST::TwilioError` doesn't end up raising `NoMethodError`s instead. It no longer makes sense for `Twilio::REST::TwilioError` to have a body, but since it did before this change I don't want to break anything. Read more about the actual thought process for this in the comments to #391.