### PR TITLE
Stops proxy warning from Faraday.

### DIFF
--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -25,7 +25,7 @@ module Twilio
           f.headers = request.headers
           f.basic_auth(request.auth[0], request.auth[1])
           if @proxy_addr
-            f.proxy "#{@proxy_user}:#{@proxy_pass}@#{@proxy_addr}:#{@proxy_port}"
+            f.proxy = "#{@proxy_user}:#{@proxy_pass}@#{@proxy_addr}:#{@proxy_port}"
           end
           f.options.open_timeout = request.timeout || @timeout
           f.options.timeout = request.timeout || @timeout


### PR DESCRIPTION
Faraday warns that `connection.proxy` will be removed in version 1.0. Instead, we should use `connection.proxy=`.

I found this from #390 which seems like a bigger issue. I don't have any experience with proxies like this, so I'm not sure what to do. It definitely seems as though lacking a protocol isn't a good thing. Also, if the proxy doesn't require a username and password then the URL will also be misformed.

I'm not sure how to test with an http proxy, but I feel like this needs some work. If someone can point me in the right direction I'd be happy to try to fix this up.