### PR TITLE
Allows developers to add comments to TwiML

### DIFF
--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -12,6 +12,16 @@ module Twilio
   module TwiML
     class TwiMLError < StandardError; end
 
+    class Comment
+      def initialize(body)
+        @body = body
+      end
+
+      def xml(document)
+        Nokogiri::XML::Comment.new(document, @body)
+      end
+    end
+
     class TwiML
         attr_accessor :name
 
@@ -68,10 +78,16 @@ module Twilio
         end
 
         def append(verb)
-          raise TwiMLError, 'Only appending of TwiML is allowed' unless verb.is_a?(TwiML)
+          unless verb.is_a?(TwiML) || verb.is_a?(Comment)
+              raise TwiMLError, 'Only appending of TwiML is allowed'
+          end
 
           @verbs << verb
           self
+        end
+
+        def comment(body)
+          append(Comment.new(body))
         end
 
       alias to_xml to_s

--- a/spec/twiml/messaging_response_spec.rb
+++ b/spec/twiml/messaging_response_spec.rb
@@ -20,6 +20,12 @@ describe Twilio::TwiML::MessagingResponse do
       expect(doc).to be_equivalent_to(expected_doc).respecting_element_order
     end
 
+    it 'should allow comments' do
+      twiml = Twilio::TwiML::MessagingResponse.new
+      twiml.comment "This is awesome"
+      expect(twiml.to_xml).to match(/<!--This is awesome-->/)
+    end
+
     it 'should allow populated response' do
       expected_doc = parse <<-XML
         <Response>

--- a/spec/twiml/voice_response_spec.rb
+++ b/spec/twiml/voice_response_spec.rb
@@ -30,6 +30,12 @@ describe Twilio::TwiML::VoiceResponse do
       expect(twiml).not_to match(/\A<\?xml version="1.0" encoding="UTF-8"\?>/)
     end
 
+    it 'should allow comments' do
+      twiml = Twilio::TwiML::VoiceResponse.new
+      twiml.comment "This is awesome"
+      expect(twiml.to_xml).to match(/<!--This is awesome-->/)
+    end
+
     it 'should allow populated response' do
       expected_doc = parse <<-XML
         <Response>


### PR DESCRIPTION
Does what it says on the tin.

```ruby
voice_response = Twilio::TwiML::VoiceResponse.new
voice_response.comment("hello")
voice_response.to_s
# => "<Response><!--hello--></Response>"
```