### PR TITLE
Add validate_ssl_certificate helper method to Client

### DIFF
--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -377,6 +377,13 @@ module Twilio
       end
 
       ##
+      # @return [Bool] indicating whether requests to the new SSL certificate are valid
+      def validate_ssl_certificate
+        response = request('api.twilio.com', '8443', 'GET', 'https://api.twilio.com:8443/.json')
+        response.status_code >= 200 && response.status_code < 300
+      end
+
+      ##
       # Provide a user friendly representation
       def to_s
         "#<Twilio::REST::Client #{@account_sid}>"

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -53,4 +53,9 @@ describe Twilio::REST::Client do
     @holodeck.mock Twilio::Response.new(200, '')
     expect(@client.validate_ssl_certificate).to be true
   end
+
+  it 'fails to validate broken SSL certificates' do
+    @holodeck.mock Twilio::Response.new(504, '')
+    expect(@client.validate_ssl_certificate).to be false
+  end
 end

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -47,3 +47,10 @@ describe Twilio::REST::TrunkingClient do
     expect { Twilio::REST::TrunkingClient.new }.to raise_error(Twilio::REST::ObsoleteError)
   end
 end
+
+describe Twilio::REST::Client do
+  it 'successfully validates the working SSL certificate' do
+    @holodeck.mock Twilio::Response.new(200, '')
+    expect(@client.validate_ssl_certificate).to be true
+  end
+end


### PR DESCRIPTION
Add `Twilio::REST::Client#validate_ssl_certificate` to check whether we can successfully make requests to the endpoint that uses the new SSL certificate.