### PR TITLE
Allow adding text nodes to TwiML responses

### DIFF
--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -26,7 +26,7 @@ module Twilio
 
     class Text < LeafNode
       def xml(document)
-        Nokogiri::XML::Text.new(document, @content)
+        Nokogiri::XML::Text.new(@content, document)
       end
     end
 

--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -98,7 +98,7 @@ module Twilio
           append(Comment.new(body))
         end
 
-        def text(content)
+        def add_text(content)
           append(Text.new(content))
         end
 

--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -12,13 +12,21 @@ module Twilio
   module TwiML
     class TwiMLError < StandardError; end
 
-    class Comment
-      def initialize(body)
-        @body = body
+    class LeafNode
+      def initialize(content)
+        @content = content
       end
+    end
 
+    class Comment < LeafNode
       def xml(document)
-        Nokogiri::XML::Comment.new(document, @body)
+        Nokogiri::XML::Comment.new(document, @content)
+      end
+    end
+
+    class Text < LeafNode
+      def xml(document)
+        Nokogiri::XML::Text.new(document, @content)
       end
     end
 
@@ -78,7 +86,7 @@ module Twilio
         end
 
         def append(verb)
-          unless verb.is_a?(TwiML) || verb.is_a?(Comment)
+          unless verb.is_a?(TwiML) || verb.is_a?(LeafNode)
               raise TwiMLError, 'Only appending of TwiML is allowed'
           end
 
@@ -88,6 +96,10 @@ module Twilio
 
         def comment(body)
           append(Comment.new(body))
+        end
+
+        def text(content)
+          append(Text.new(content))
         end
 
       alias to_xml to_s

--- a/spec/twiml/messaging_response_spec.rb
+++ b/spec/twiml/messaging_response_spec.rb
@@ -28,7 +28,7 @@ describe Twilio::TwiML::MessagingResponse do
 
     it 'should allow text nodes' do
       twiml = Twilio::TwiML::MessagingResponse.new
-      twiml.text 'Look no tags'
+      twiml.add_text 'Look no tags'
       expect(twiml.to_xml).to include('<Response>Look no tags</Response>')
     end
 

--- a/spec/twiml/messaging_response_spec.rb
+++ b/spec/twiml/messaging_response_spec.rb
@@ -26,6 +26,12 @@ describe Twilio::TwiML::MessagingResponse do
       expect(twiml.to_xml).to match(/<!--This is awesome-->/)
     end
 
+    it 'should allow text nodes' do
+      twiml = Twilio::TwiML::MessagingResponse.new
+      twiml.text 'Look no tags'
+      expect(twiml.to_xml).to include('<Response>Look no tags</Response>')
+    end
+
     it 'should allow populated response' do
       expected_doc = parse <<-XML
         <Response>

--- a/spec/twiml/voice_response_spec.rb
+++ b/spec/twiml/voice_response_spec.rb
@@ -36,6 +36,12 @@ describe Twilio::TwiML::VoiceResponse do
       expect(twiml.to_xml).to match(/<!--This is awesome-->/)
     end
 
+    it 'should allow text nodes' do
+      twiml = Twilio::TwiML::VoiceResponse.new
+      twiml.text 'Look no tags'
+      expect(twiml.to_xml).to include('<Response>Look no tags</Response>')
+    end
+
     it 'should allow populated response' do
       expected_doc = parse <<-XML
         <Response>

--- a/spec/twiml/voice_response_spec.rb
+++ b/spec/twiml/voice_response_spec.rb
@@ -38,7 +38,7 @@ describe Twilio::TwiML::VoiceResponse do
 
     it 'should allow text nodes' do
       twiml = Twilio::TwiML::VoiceResponse.new
-      twiml.text 'Look no tags'
+      twiml.add_text 'Look no tags'
       expect(twiml.to_xml).to include('<Response>Look no tags</Response>')
     end
 


### PR DESCRIPTION
Add method `TwiML#add_text` to add a text node to a TwiML response.