### PR TITLE
Add Dockerfile and related changes to build the Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,8 @@ before_install:
   # Bundler on Travis may be too out of date
   # Update bundler to a recent version.
   - gem install bundler
+deploy:
+  script:
+    - make docker-build
+    - make docker-push
+  on: tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.4.0
+
+RUN mkdir /twilio
+WORKDIR /twilio
+
+COPY . .
+
+RUN bundle install 
+RUN bundle exec rake install

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,16 @@ authors:
 
 gem:
 	bundle exec rake build | sed -e 's/.*pkg/pkg/g' | sed -e "s/\.$$//g" | xargs gem push
+
+API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
+docker-build:
+	docker build -t twilio/twilio-ruby .
+	docker tag twilio/twilio-ruby twilio/twilio-ruby:${TRAVIS_TAG}
+	docker tag twilio/twilio-ruby twilio/twilio-ruby:apidefs=${API_DEFINITIONS_SHA}
+
+docker-push:
+	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	docker push twilio/twilio-ruby:${TRAVIS_TAG}
+	docker push twilio/twilio-ruby:${API_DEFINITIONS_TAG}
+
+.PHONY: all clean test docs docs-install test-install authors

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ make install
 ## Documentation
 [Here][documentation]
 
+## Docker Image
+The `Dockerfile` present in this repository and its respective `twilio/twilio-ruby` Docker image are used by Twilio for testing purposes only.
+
 ## Feedback
 During the Release Candidate period of this library, please leave all feedback and issues in the [Github Issues][issues] for `twilio-ruby`.
 


### PR DESCRIPTION
Hi there!

This PR adds the Dockerfile and related files to build the lib Docker image. This image will be used mainly by Tricorder to generate further Tricorder worker images with the specific lib version.

The tags used in the Docker images are the version (from the release tag) and the api-definitions SHA from the release.

TODO:

- [ ] Add Docker Hub credentials to the TravisCI env
- [ ] Merge and create a release for testing