### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](http://img.shields.io/travis/twilio/twilio-ruby.svg)][travis]
 [![Gem Version](http://img.shields.io/gem/v/twilio-ruby.svg)](https://rubygems.org/gems/twilio-ruby)
 [![Code Quality](http://img.shields.io/codeclimate/github/twilio/twilio-ruby.svg)][codeclimate]
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=twilio-ruby&package-manager=bundler&version-scheme=semver&target-version=latest)](https://dependabot.com/compatibility-score.html?dependency-name=twilio-ruby&package-manager=bundler&version-scheme=semver&new-version=latest)
 
 A module for using the Twilio REST API and generating valid [TwiML](http://www.twilio.com/docs/api/twiml/ "TwiML - Twilio Markup Language"). [Click here to read the full documentation.][documentation]
 


### PR DESCRIPTION
Adds a SemVer stability badge to the readme that displays the percentage of CI runs that pass when updating `twlio-ruby` from SemVer compatible versions to the latest one. Data comes from Dependabot (disclosure: I built it).

Here's what the badge looks like:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=twilio-ruby&package-manager=bundler&version-scheme=semver&target-version=latest)](https://dependabot.com/compatibility-score.html?dependency-name=twilio-ruby&package-manager=bundler&version-scheme=semver&new-version=latest)

The idea behind the badge is that it makes it obvious if/when a new version is released that contains bugs/backwards compatibility issues. It also makes it clear that twilio-ruby follows SemVer.