### PR TITLE
Remove support for ruby 2.0 and 2.1, adds 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ bundler_args: --without development
 
 rvm:
   - ruby-head
+  - 2.5.0
   - 2.4.0
   - 2.3.0
   - 2.2.0
-  - 2.1
-  - 2.0.0
   - jruby-9.1.9.0
 
 services:

--- a/README.md
+++ b/README.md
@@ -178,11 +178,10 @@ This will print the following (except for the whitespace):
 This library supports and is [tested against][travis] the following Ruby
 implementations:
 
+- Ruby 2.5.1
 - Ruby 2.4.0
 - Ruby 2.3.0
 - Ruby 2.2.0
-- Ruby 2.1.0
-- Ruby 2.0.0
 
 [capability]: https://github.com/twilio/twilio-ruby/wiki/JWT-Tokens
 [examples]: https://github.com/twilio/twilio-ruby/blob/master/examples

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This will print the following (except for the whitespace):
 This library supports and is [tested against][travis] the following Ruby
 implementations:
 
-- Ruby 2.5.1
+- Ruby 2.5.0
 - Ruby 2.4.0
 - Ruby 2.3.0
 - Ruby 2.2.0


### PR DESCRIPTION
These rubies have now been end-of-life for over a year.