### PR TITLE
Add a request body validator

### DIFF
--- a/lib/twilio-ruby/security/request_validator.rb
+++ b/lib/twilio-ruby/security/request_validator.rb
@@ -4,7 +4,7 @@ module Twilio
   module Security
     class RequestValidator
       ##
-      # Initialize a Request Validator. quth_token will either be grabbed from the global Twilio object or you can
+      # Initialize a Request Validator. auth_token will either be grabbed from the global Twilio object or you can
       # pass it in here.
       #
       # @param [String] auth_token Your account auth token, used to sign requests

--- a/lib/twilio-ruby/security/request_validator.rb
+++ b/lib/twilio-ruby/security/request_validator.rb
@@ -3,13 +3,29 @@
 module Twilio
   module Security
     class RequestValidator
+      ##
+      # Initialize a Request Validator. quth_token will either be grabbed from the global Twilio object or you can
+      # pass it in here.
+      #
+      # @param [String] auth_token Your account auth token, used to sign requests
       def initialize(auth_token = nil)
         @auth_token = auth_token || Twilio.auth_token
         raise ArgumentError, 'Auth token is required' if @auth_token.nil?
       end
 
+      ##
+      # Validates that after hashing a request with Twilio's request-signing algorithm
+      # (https://www.twilio.com/docs/usage/security#validating-requests), the hash matches the signature parameter
+      #
+      # @param [String] url The url sent to your server, including any query parameters
+      # @param [String, Hash, #to_unsafe_h] params In most cases, this is the POST parameters as a hash. If you received
+      #   a bodySHA256 parameter in the query string, this parameter can instead be the POST body as a string to
+      #   validate JSON or other text-based payloads that aren't x-www-form-urlencoded.
+      # @param [String] signature The expected signature, from the X-Twilio-Signature header of the request
+      #
+      # @return [Boolean] whether or not the computed signature matches the signature parameter
       def validate(url, params, signature)
-        params_hash = params_to_hash(params)
+        params_hash = body_or_hash(params)
         if params_hash.is_a? Enumerable
           expected = build_signature_for(url, params_hash)
           secure_compare(expected, signature)
@@ -21,11 +37,24 @@ module Twilio
         end
       end
 
+      ##
+      # Build a SHA256 hash for a body string
+      #
+      # @param [String] body String to hash
+      #
+      # @return [String] A base64-encoded SHA256 of the body string
       def build_hash_for(body)
         hasher = OpenSSL::Digest.new('sha256')
         Base64.encode64(hasher.digest(body)).strip
       end
 
+      ##
+      # Build a SHA1-HMAC signature for a url and parameter hash
+      #
+      # @param [String] url The request url, including any query parameters
+      # @param [#join] params The POST parameters
+      #
+      # @return [String] A base64 encoded SHA1-HMAC
       def build_signature_for(url, params)
         data = url + params.sort.join
         digest = OpenSSL::Digest.new('sha1')
@@ -56,11 +85,11 @@ module Twilio
       #
       # We use `to_unsafe_h` as `to_h` returns a hash of the permitted
       # parameters only and we need all the parameters to create the signature.
-      def params_to_hash(params)
-        if params.respond_to?(:to_unsafe_h)
-          params.to_unsafe_h
+      def body_or_hash(params_or_body)
+        if params_or_body.respond_to?(:to_unsafe_h)
+          params_or_body.to_unsafe_h
         else
-          params
+          params_or_body
         end
       end
     end


### PR DESCRIPTION
Key thing to consider for this implementation:

Because you can't overload in Ruby, I propose here checking if `params_hash` is `Enumerable`. If not, then we assume it's just a string (because `params_to_hash` has already attempted to convert it to a hash), which means it's a POST body instead of argument array.

This also refactors the tests to be in line with tests in the other libraries, removing redundant tests.