### PR TITLE
Tag and push Docker latest image when deploying with TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,10 @@ docker-build:
 	docker build -t twilio/twilio-ruby .
 	docker tag twilio/twilio-ruby twilio/twilio-ruby:${TRAVIS_TAG}
 	docker tag twilio/twilio-ruby twilio/twilio-ruby:apidefs-${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-ruby twilio/twilio-ruby:latest
 
 docker-push:
 	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-ruby:${TRAVIS_TAG}
 	docker push twilio/twilio-ruby:apidefs-${API_DEFINITIONS_SHA}
+	docker push twilio/twilio-ruby:latest


### PR DESCRIPTION
Necessary image tag to be used with Tricorder.