### PR TITLE
Remove jruby-openssl requirement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ services:
 matrix:
   fast_finish: true
 
-before_install:
-  # Bundler on Travis may be too out of date
-  # Update bundler to a recent version.
-  - gem install bundler
 deploy:
   provider: script
   script: make docker-build && make docker-push

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('jwt', '>= 1.5', '<= 2.5')
   spec.add_dependency('nokogiri', '>= 1.6', '< 2.0')
   spec.add_dependency('faraday', '~>0.9')
-  spec.add_dependency('jruby-openssl', '>= 0.9.6') if RUBY_PLATFORM == 'java'
   # Workaround for RBX <= 2.2.1, should be fixed in next version
   spec.add_dependency('rubysl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 


### PR DESCRIPTION
Turns out we didn't need jruby-openssl. I thought it was required for
the signature verification but it turns out that JRuby ships enough
OpenSSL to do what we need (https://www.jruby.org/openssl).

Forcing an install of bundler on Travis is unnecessary too. Travis will
install a version of bundler and as long as it is within our supported
range it should work. Forcing an install will make Travis try to install
bundler on Ruby 2.2 which no longer works as Bundler 2 only supports
Ruby 2.3 and up.

Please ensure the following steps have been run before submitting this pull request:

- [x] Run `make test` and ensure it passes locally
- [x] Run `make lint` to appease Rubocop
