### PR TITLE
Allow to use faraday 0.10 or later

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('jwt', '>= 1.5', '<= 2.5')
   spec.add_dependency('nokogiri', '>= 1.6', '< 2.0')
-  spec.add_dependency('faraday', '~>0.9')
+  spec.add_dependency('faraday', '>=0.9')
   # Workaround for RBX <= 2.2.1, should be fixed in next version
   spec.add_dependency('rubysl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 


### PR DESCRIPTION
## Motivation

I'd like to use `twilio-ruby` with other gems which require `faraday` v0.10 or later.

## Change

With this pull request, it allows `twilio-ruby` users to use `faraday` v0.10 or later.

I saw git log and found that the faraday version has been fixed since https://github.com/twilio/twilio-ruby/commit/33e5c3bff5b9f916d7321ac6f272c40e7c4e4fbb, which introduced faraday into this project. Besides, I wasn't able to find any reason to reject faraday 0.10 or later. (I'm sorry if I'd miss any discussion or decision for that.)

---

Please ensure the following steps have been run before submitting this pull request:

- [x] Run `make test` and ensure it passes locally
   - Passed
- [x] Run `make lint` to appease Rubocop
   - It shows some erros but they all happen on `master` branch as well