### PR TITLE
Reduce line length to satisfy rubocop constraints

### DIFF
--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -8,8 +8,8 @@ module Twilio
       attr_accessor :adapter
       attr_reader :timeout, :last_response, :last_request
 
-      def initialize(proxy_prot = nil, proxy_addr = nil, proxy_port = nil, proxy_user = nil, proxy_pass = nil, ssl_ca_file = nil,
-                     timeout: nil)
+      def initialize(proxy_prot = nil, proxy_addr = nil, proxy_port = nil, proxy_user = nil, proxy_pass = nil,
+                     ssl_ca_file = nil, timeout: nil)
         @proxy_prot = proxy_prot
         @proxy_addr = proxy_addr
         @proxy_port = proxy_port


### PR DESCRIPTION
Fix line length to comply with rubocop constraints. I think #399 should have not passed `make lint`?