### PR TITLE
Use the 'base_url' instead of the 'host' for HTTP client URL

### DIFF
--- a/lib/twilio-ruby/framework/domain.rb
+++ b/lib/twilio-ruby/framework/domain.rb
@@ -20,7 +20,7 @@ module Twilio
         url = uri.match(/^http/) ? uri : absolute_url(uri)
 
         @client.request(
-          @host,
+          @base_url,
           @port,
           method,
           url,


### PR DESCRIPTION
The `base_url` contains the full URL (e.g., `https://api.twilio.com`).

Fixes #356 
Fixes #440 