### PR TITLE
Add a global configuration for the HTTP client

### DIFF
--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -45,7 +45,7 @@ end
 module Twilio
   extend SingleForwardable
 
-  def_delegators :configuration, :account_sid, :auth_token
+  def_delegators :configuration, :account_sid, :auth_token, :http_client
 
   ##
   # Pre-configure with account SID and auth token so that you don't need to

--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -15,14 +15,14 @@ module Twilio
 
       ##
       # Initializes the Twilio Client
-      def initialize(username=nil, password=nil, account_sid=nil, region=nil, http_client=Twilio::HTTP::Client.new)
+      def initialize(username=nil, password=nil, account_sid=nil, region=nil, http_client=nil)
         @username = username || Twilio.account_sid
         @password = password || Twilio.auth_token
         @region = region
         @account_sid = account_sid || @username
         @auth_token = @password
         @auth = [@username, @password]
-        @http_client = http_client
+        @http_client = http_client || Twilio.http_client || Twilio::HTTP::Client.new
 
         # Domains
         @accounts = nil

--- a/lib/twilio-ruby/util/configuration.rb
+++ b/lib/twilio-ruby/util/configuration.rb
@@ -3,13 +3,18 @@
 module Twilio
   module Util
     class Configuration
-      attr_accessor :account_sid, :auth_token
-      def account_sid=value
-        @account_sid=value
+      attr_accessor :account_sid, :auth_token, :http_client
+
+      def account_sid=(value)
+        @account_sid = value
       end
 
-      def auth_token=value
-        @auth_token=value
+      def auth_token=(value)
+        @auth_token = value
+      end
+
+      def http_client=(value)
+        @http_client = value
       end
     end
   end

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -49,6 +49,28 @@ describe Twilio::REST::TrunkingClient do
 end
 
 describe Twilio::REST::Client do
+  before do
+    Twilio.configure do |config|
+      config.account_sid = 'someSid'
+      config.auth_token = 'someToken'
+      config.http_client = 'someClient'
+    end
+  end
+
+  it 'uses the global configuration by default' do
+    @client = Twilio::REST::Client.new
+    expect(@client.account_sid).to eq('someSid')
+    expect(@client.auth_token).to eq('someToken')
+    expect(@client.http_client).to eq('someClient')
+  end
+
+  it 'uses the arguments over global configuration' do
+    @client = Twilio::REST::Client.new('myUser', 'myPassword', nil, nil, 'myClient')
+    expect(@client.account_sid).to eq('myUser')
+    expect(@client.auth_token).to eq('myPassword')
+    expect(@client.http_client).to eq('myClient')
+  end
+
   it 'successfully validates the working SSL certificate' do
     @holodeck.mock Twilio::Response.new(200, '')
     expect { @client.validate_ssl_certificate }.not_to raise_error

--- a/spec/twilio_spec.rb
+++ b/spec/twilio_spec.rb
@@ -3,13 +3,15 @@ describe Twilio do
     Twilio.instance_variable_set('@configuration', nil)
   end
 
-  it 'should set the account sid and auth token with a config block' do
+  it 'should set the configuration with a config block' do
     Twilio.configure do |config|
       config.account_sid = 'someSid'
       config.auth_token = 'someToken'
+      config.http_client = 'someClient'
     end
 
     expect(Twilio.account_sid).to eq('someSid')
     expect(Twilio.auth_token).to eq('someToken')
+    expect(Twilio.http_client).to eq('someClient')
   end
 end

--- a/spec/util/configuration_spec.rb
+++ b/spec/util/configuration_spec.rb
@@ -12,4 +12,10 @@ describe Twilio::Util::Configuration do
     config.auth_token = 'someToken'
     expect(config.auth_token).to eq('someToken')
   end
+
+  it 'should have an http client attribute' do
+    config = Twilio::Util::Configuration.new
+    config.http_client = 'someClient'
+    expect(config.http_client).to eq('someClient')
+  end
 end


### PR DESCRIPTION
Please ensure the following steps have been run before submitting this pull request:

- [x] Run `make test` and ensure it passes locally
- [x] Run `make lint` to appease Rubocop

Fixes #401 