### PR TITLE
Drop support for Ruby < 2.4 and add 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ bundler_args: --without development
 
 rvm:
   - ruby-head
-  - 2.5.0
-  - 2.4.0
-  - 2.3.0
-  - 2.2.0
-  - jruby-9.1.9.0
+  - 2.6
+  - 2.5
+  - 2.4
+  - jruby
 
 services:
   - docker
@@ -26,4 +25,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    rvm: "2.4.0"
+    rvm: "2.4"

--- a/README.md
+++ b/README.md
@@ -182,13 +182,11 @@ This will print the following (except for the whitespace):
 
 ## Supported Ruby Versions
 
-This library supports and is [tested against][travis] the following Ruby
-implementations:
+This library supports and is [tested against][travis] the following Ruby implementations:
 
-- Ruby 2.5.0
-- Ruby 2.4.0
-- Ruby 2.3.0
-- Ruby 2.2.0
+- Ruby 2.6.X
+- Ruby 2.5.X
+- Ruby 2.4.X
 
 [apidocs]: https://www.twilio.com/docs/api
 [twiml]: https://www.twilio.com/docs/api/twiml


### PR DESCRIPTION
All support for Ruby 2.3 ended earlier this year: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/

Ruby 2.6 was released earlier this year: https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/