### PR TITLE
chore: autoload TwiML to save memory on load

### DIFF
--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -2,7 +2,6 @@
 
 require 'net/http'
 require 'net/https'
-require 'nokogiri'
 require 'cgi'
 require 'openssl'
 require 'base64'
@@ -22,11 +21,6 @@ require 'twilio-ruby/jwt/task_router'
 require 'twilio-ruby/security/request_validator'
 require 'twilio-ruby/util/configuration'
 
-require 'twilio-ruby/twiml/twiml'
-require 'twilio-ruby/twiml/fax_response'
-require 'twilio-ruby/twiml/messaging_response'
-require 'twilio-ruby/twiml/voice_response'
-
 Dir[File.dirname(__FILE__) + '/twilio-ruby/http/**/*.rb'].sort.each do |file|
   require file
 end
@@ -45,6 +39,8 @@ end
 
 module Twilio
   extend SingleForwardable
+
+  autoload :TwiML, File.join(File.dirname(__FILE__), 'twilio-ruby', 'twiml', 'twiml.rb')
 
   def_delegators :configuration, :account_sid, :auth_token, :http_client
 

--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -2,6 +2,10 @@ require 'nokogiri'
 
 module Twilio
   module TwiML
+    autoload :FaxResponse, File.join(File.dirname(__FILE__), "fax_response.rb")
+    autoload :VoiceResponse, File.join(File.dirname(__FILE__), "voice_response.rb")
+    autoload :MessagingResponse, File.join(File.dirname(__FILE__), "messaging_response.rb")
+
     class TwiMLError < StandardError; end
 
     class LeafNode

--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -3,9 +3,9 @@ require 'nokogiri'
 module Twilio
   module TwiML
     autoload :FaxResponse, File.join(File.dirname(__FILE__), "fax_response.rb")
-    autoload :VoiceResponse, File.join(File.dirname(__FILE__), "voice_response.rb")
     autoload :MessagingResponse, File.join(File.dirname(__FILE__), "messaging_response.rb")
-
+    autoload :VoiceResponse, File.join(File.dirname(__FILE__), "voice_response.rb")
+    
     class TwiMLError < StandardError; end
 
     class LeafNode


### PR DESCRIPTION
Works towards fixing #396.

Others are reporting that `twilio-ruby` takes a lot of memory. My belief is that this is because it is a large library that covers an ever increasing API surface. The issue is not necessarily in that the library is so large, but that the entire thing is loaded in one go with `require`s for days.

I am going to send a few PRs that update our use of `require` to `autoload` where appropriate. `autoload` only loads the file when the constant (class/module) is used. In this first PR, for those who include the library but don't use TwiML, the files governing TwiML creation will not be loaded into memory. For those that do use TwiML the behaviour will be unchanged. Notably this also moves requiring `nokogiri` to the TwiML files too. This will not affect a Rails user, but users of frameworks which don't include `nokogiri` should notice a difference.

This first PR will not significantly reduce the memory usage, but it is a start and smaller PRs are easier to review.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the master branch
- [x] I have added tests that prove my fix is effective or that my feature works (all existing tests pass)
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

