### PR TITLE
chore: Refer to https:// homepage in gemspec

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
                        'building TwiML, and generating Twilio JWT Capability Tokens'
   spec.description   = 'The official library for communicating with the Twilio REST API, '\
                        'building TwiML, and generating Twilio JWT Capability Tokens'
-  spec.homepage      = 'http://github.com/twilio/twilio-ruby'
+  spec.homepage      = 'https://github.com/twilio/twilio-ruby'
   spec.license       = 'MIT'
   spec.metadata      = { 'yard.run' => 'yri' } # use "yard" to build full HTML docs
 


### PR DESCRIPTION
# Fixes #

This PR changes the gemspec's `homepage` property to use `https://`.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the master branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
