### PR TITLE
docs: fix readme about error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ message_sid = 'SMxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 ```ruby
 begin
   messages = @client.messages.list(limit: 20)
-rescue Twilio::REST::TwilioError => e
+rescue Twilio::REST::RestError => e
   puts e.message
 end
 ```


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

hello, I fixed README about error handling.
`Twilio::REST::TwilioError` class is deprecated so fixed `TwilioError` -> `RestError`.
https://github.com/twilio/twilio-ruby/blob/5.33.0/lib/twilio-ruby/framework/error.rb

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them


