### PR TITLE
fix: use ruby keyword arguments for all action methods

### DIFF
--- a/lib/twilio-ruby/framework/version.rb
+++ b/lib/twilio-ruby/framework/version.rb
@@ -127,7 +127,7 @@ module Twilio
         }
       end
 
-      def page(method, uri, params = {}, data = {}, headers: {}, auth: nil, timeout: nil)
+      def page(method, uri, params: {}, data: {}, headers: {}, auth: nil, timeout: nil)
         request(
           method,
           uri,

--- a/lib/twilio-ruby/rest/accounts/v1/credential/aws.rb
+++ b/lib/twilio-ruby/rest/accounts/v1/credential/aws.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AwsPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/accounts/v1/credential/public_key.rb
+++ b/lib/twilio-ruby/rest/accounts/v1/credential/public_key.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               PublicKeyPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account.rb
@@ -117,7 +117,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             AccountPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/api/v2010/account/address.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/address.rb
@@ -156,7 +156,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AddressPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/address/dependent_phone_number.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/address/dependent_phone_number.rb
@@ -92,7 +92,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 DependentPhoneNumberPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/application.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/application.rb
@@ -155,7 +155,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ApplicationPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/authorized_connect_app.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/authorized_connect_app.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AuthorizedConnectAppPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number.rb
@@ -88,7 +88,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AvailablePhoneNumberCountryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/local.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/local.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 LocalPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/machine_to_machine.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/machine_to_machine.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MachineToMachinePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/mobile.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/mobile.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MobilePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/national.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/national.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 NationalPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/shared_cost.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/shared_cost.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SharedCostPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/toll_free.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/toll_free.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 TollFreePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/voip.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/available_phone_number/voip.rb
@@ -303,7 +303,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 VoipPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/call.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call.rb
@@ -335,7 +335,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CallPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/call/notification.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call/notification.rb
@@ -128,7 +128,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 NotificationPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/call/recording.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call/recording.rb
@@ -158,7 +158,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 RecordingPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/conference.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/conference.rb
@@ -148,7 +148,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ConferencePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/conference/participant.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/conference/participant.rb
@@ -296,7 +296,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ParticipantPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/conference/recording.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/conference/recording.rb
@@ -115,7 +115,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 RecordingPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/connect_app.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/connect_app.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ConnectAppPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number.rb
@@ -141,7 +141,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               IncomingPhoneNumberPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/assigned_add_on.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/assigned_add_on.rb
@@ -94,7 +94,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 AssignedAddOnPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/assigned_add_on/assigned_add_on_extension.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/assigned_add_on/assigned_add_on_extension.rb
@@ -101,7 +101,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   AssignedAddOnExtensionPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/local.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/local.rb
@@ -134,7 +134,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 LocalPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/mobile.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/mobile.rb
@@ -134,7 +134,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MobilePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/toll_free.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/incoming_phone_number/toll_free.rb
@@ -134,7 +134,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 TollFreePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/key.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/key.rb
@@ -88,7 +88,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               KeyPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/message.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/message.rb
@@ -226,7 +226,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               MessagePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/message/media.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/message/media.rb
@@ -115,7 +115,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MediaPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/notification.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/notification.rb
@@ -124,7 +124,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               NotificationPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/outgoing_caller_id.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/outgoing_caller_id.rb
@@ -112,7 +112,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               OutgoingCallerIdPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/queue.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/queue.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               QueuePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/queue/member.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/queue/member.rb
@@ -91,7 +91,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MemberPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/recording.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/recording.rb
@@ -133,7 +133,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RecordingPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/recording/add_on_result.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/recording/add_on_result.rb
@@ -92,7 +92,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 AddOnResultPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/recording/add_on_result/payload.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/recording/add_on_result/payload.rb
@@ -99,7 +99,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   PayloadPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/recording/transcription.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/recording/transcription.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 TranscriptionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/short_code.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/short_code.rb
@@ -115,7 +115,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ShortCodePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/signing_key.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/signing_key.rb
@@ -88,7 +88,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SigningKeyPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/credential_list.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/credential_list.rb
@@ -89,7 +89,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 CredentialListPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/credential_list/credential.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/credential_list/credential.rb
@@ -92,7 +92,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   CredentialPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/domain.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/domain.rb
@@ -89,7 +89,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 DomainPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_credential_list_mapping.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_credential_list_mapping.rb
@@ -113,7 +113,7 @@ module Twilio
                           'PageSize' => page_size,
                       })
 
-                      response = @version.page('GET', @uri, params)
+                      response = @version.page('GET', @uri, params: params)
 
                       AuthCallsCredentialListMappingPage.new(@version, response, @solution)
                     end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_ip_access_control_list_mapping.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/domain/auth_types/auth_calls_mapping/auth_calls_ip_access_control_list_mapping.rb
@@ -113,7 +113,7 @@ module Twilio
                           'PageSize' => page_size,
                       })
 
-                      response = @version.page('GET', @uri, params)
+                      response = @version.page('GET', @uri, params: params)
 
                       AuthCallsIpAccessControlListMappingPage.new(@version, response, @solution)
                     end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/domain/auth_types/auth_registrations_mapping/auth_registrations_credential_list_mapping.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/domain/auth_types/auth_registrations_mapping/auth_registrations_credential_list_mapping.rb
@@ -113,7 +113,7 @@ module Twilio
                           'PageSize' => page_size,
                       })
 
-                      response = @version.page('GET', @uri, params)
+                      response = @version.page('GET', @uri, params: params)
 
                       AuthRegistrationsCredentialListMappingPage.new(@version, response, @solution)
                     end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/domain/credential_list_mapping.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/domain/credential_list_mapping.rb
@@ -110,7 +110,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   CredentialListMappingPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/domain/ip_access_control_list_mapping.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/domain/ip_access_control_list_mapping.rb
@@ -110,7 +110,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   IpAccessControlListMappingPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/ip_access_control_list.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/ip_access_control_list.rb
@@ -89,7 +89,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 IpAccessControlListPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/sip/ip_access_control_list/ip_address.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/sip/ip_access_control_list/ip_address.rb
@@ -92,7 +92,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   IpAddressPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/transcription.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/transcription.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               TranscriptionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record.rb
@@ -164,7 +164,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 RecordPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/all_time.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/all_time.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   AllTimePage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/daily.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/daily.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   DailyPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/last_month.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/last_month.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   LastMonthPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/monthly.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/monthly.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   MonthlyPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/this_month.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/this_month.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   ThisMonthPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/today.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/today.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   TodayPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/yearly.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/yearly.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   YearlyPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/record/yesterday.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/record/yesterday.rb
@@ -155,7 +155,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   YesterdayPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/api/v2010/account/usage/trigger.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/usage/trigger.rb
@@ -172,7 +172,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 TriggerPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             AssistantPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/field_type.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/field_type.rb
@@ -91,7 +91,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               FieldTypePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/field_type/field_value.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/field_type/field_value.rb
@@ -101,7 +101,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 FieldValuePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/model_build.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/model_build.rb
@@ -91,7 +91,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ModelBuildPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/query.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/query.rb
@@ -132,7 +132,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               QueryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/task.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/task.rb
@@ -91,7 +91,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               TaskPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/task/field.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/task/field.rb
@@ -95,7 +95,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 FieldPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/task/sample.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/task/sample.rb
@@ -102,7 +102,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SamplePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/autopilot/v1/assistant/webhook.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1/assistant/webhook.rb
@@ -91,7 +91,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               WebhookPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/bulkexports/v1/export/day.rb
+++ b/lib/twilio-ruby/rest/bulkexports/v1/export/day.rb
@@ -106,7 +106,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DayPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/bulkexports/v1/export/export_custom_job.rb
+++ b/lib/twilio-ruby/rest/bulkexports/v1/export/export_custom_job.rb
@@ -112,7 +112,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ExportCustomJobPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v1/credential.rb
+++ b/lib/twilio-ruby/rest/chat/v1/credential.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CredentialPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/chat/v1/service.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service.rb
@@ -98,7 +98,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/chat/v1/service/channel.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel.rb
@@ -122,7 +122,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ChannelPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v1/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel/invite.rb
@@ -133,7 +133,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 InvitePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v1/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel/member.rb
@@ -133,7 +133,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MemberPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v1/service/channel/message.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel/message.rb
@@ -124,7 +124,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MessagePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v1/service/role.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/role.rb
@@ -113,7 +113,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RolePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v1/service/user.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/user.rb
@@ -117,7 +117,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               UserPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v1/service/user/user_channel.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/user/user_channel.rb
@@ -92,7 +92,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 UserChannelPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v2/credential.rb
+++ b/lib/twilio-ruby/rest/chat/v2/credential.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CredentialPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/chat/v2/service.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service.rb
@@ -98,7 +98,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/chat/v2/service/binding.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/binding.rb
@@ -123,7 +123,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               BindingPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v2/service/channel.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel.rb
@@ -140,7 +140,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ChannelPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/invite.rb
@@ -129,7 +129,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 InvitePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/member.rb
@@ -162,7 +162,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MemberPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/message.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/message.rb
@@ -148,7 +148,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MessagePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/webhook.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/webhook.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 WebhookPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v2/service/role.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/role.rb
@@ -113,7 +113,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RolePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v2/service/user.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/user.rb
@@ -120,7 +120,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               UserPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/chat/v2/service/user/user_binding.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/user/user_binding.rb
@@ -111,7 +111,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 UserBindingPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/chat/v2/service/user/user_channel.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/user/user_channel.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 UserChannelPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/conversations/v1/conversation.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation.rb
@@ -127,7 +127,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ConversationPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/conversations/v1/conversation/message.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation/message.rb
@@ -122,7 +122,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               MessagePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/conversations/v1/conversation/message/delivery_receipt.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation/message/delivery_receipt.rb
@@ -92,7 +92,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 DeliveryReceiptPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/conversations/v1/conversation/participant.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation/participant.rb
@@ -138,7 +138,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ParticipantPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/conversations/v1/conversation/webhook.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation/webhook.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               WebhookPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/fax/v1/fax.rb
+++ b/lib/twilio-ruby/rest/fax/v1/fax.rb
@@ -134,7 +134,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             FaxPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/fax/v1/fax/fax_media.rb
+++ b/lib/twilio-ruby/rest/fax/v1/fax/fax_media.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               FaxMediaPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/flex_api/v1/channel.rb
+++ b/lib/twilio-ruby/rest/flex_api/v1/channel.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ChannelPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/flex_api/v1/configuration.rb
+++ b/lib/twilio-ruby/rest/flex_api/v1/configuration.rb
@@ -79,7 +79,7 @@ module Twilio
           def fetch(ui_version: :unset)
             params = Twilio::Values.of({'UiVersion' => ui_version, })
 
-            payload = @version.fetch('GET', @uri, params)
+            payload = @version.fetch('GET', @uri, params: params)
 
             ConfigurationInstance.new(@version, payload, )
           end

--- a/lib/twilio-ruby/rest/flex_api/v1/flex_flow.rb
+++ b/lib/twilio-ruby/rest/flex_api/v1/flex_flow.rb
@@ -92,7 +92,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             FlexFlowPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/flex_api/v1/web_channel.rb
+++ b/lib/twilio-ruby/rest/flex_api/v1/web_channel.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             WebChannelPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/insights/v1/call/event.rb
+++ b/lib/twilio-ruby/rest/insights/v1/call/event.rb
@@ -93,7 +93,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               EventPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/insights/v1/call/metric.rb
+++ b/lib/twilio-ruby/rest/insights/v1/call/metric.rb
@@ -97,7 +97,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               MetricPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/insights/v1/call/summary.rb
+++ b/lib/twilio-ruby/rest/insights/v1/call/summary.rb
@@ -87,7 +87,7 @@ module Twilio
             def fetch(processing_state: :unset)
               params = Twilio::Values.of({'ProcessingState' => processing_state, })
 
-              payload = @version.fetch('GET', @uri, params)
+              payload = @version.fetch('GET', @uri, params: params)
 
               CallSummaryInstance.new(@version, payload, call_sid: @solution[:call_sid], )
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/credential.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/credential.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CredentialPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service.rb
@@ -98,7 +98,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel.rb
@@ -122,7 +122,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ChannelPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/invite.rb
@@ -133,7 +133,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 InvitePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/member.rb
@@ -133,7 +133,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MemberPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/message.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/message.rb
@@ -124,7 +124,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MessagePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/role.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/role.rb
@@ -113,7 +113,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RolePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/user.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/user.rb
@@ -117,7 +117,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               UserPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/user/user_channel.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/user/user_channel.rb
@@ -92,7 +92,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 UserChannelPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/credential.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/credential.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CredentialPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service.rb
@@ -98,7 +98,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/binding.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/binding.rb
@@ -123,7 +123,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               BindingPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel.rb
@@ -140,7 +140,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ChannelPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/invite.rb
@@ -129,7 +129,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 InvitePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/member.rb
@@ -162,7 +162,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MemberPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/message.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/message.rb
@@ -148,7 +148,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 MessagePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/webhook.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/webhook.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 WebhookPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/role.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/role.rb
@@ -113,7 +113,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RolePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/user.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/user.rb
@@ -120,7 +120,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               UserPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/user/user_binding.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/user/user_binding.rb
@@ -111,7 +111,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 UserBindingPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/user/user_channel.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/user/user_channel.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 UserChannelPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/lookups/v1/phone_number.rb
+++ b/lib/twilio-ruby/rest/lookups/v1/phone_number.rb
@@ -102,7 +102,7 @@ module Twilio
             })
             params.merge!(Twilio.prefixed_collapsible_map(add_ons_data, 'AddOns'))
 
-            payload = @version.fetch('GET', @uri, params)
+            payload = @version.fetch('GET', @uri, params: params)
 
             PhoneNumberInstance.new(@version, payload, phone_number: @solution[:phone_number], )
           end

--- a/lib/twilio-ruby/rest/messaging/v1/service.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service.rb
@@ -147,7 +147,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/messaging/v1/service/alpha_sender.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service/alpha_sender.rb
@@ -105,7 +105,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AlphaSenderPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/messaging/v1/service/phone_number.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service/phone_number.rb
@@ -104,7 +104,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               PhoneNumberPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/messaging/v1/service/short_code.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service/short_code.rb
@@ -104,7 +104,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ShortCodePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/monitor/v1/alert.rb
+++ b/lib/twilio-ruby/rest/monitor/v1/alert.rb
@@ -123,7 +123,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             AlertPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/monitor/v1/event.rb
+++ b/lib/twilio-ruby/rest/monitor/v1/event.rb
@@ -153,7 +153,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             EventPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/notify/v1/credential.rb
+++ b/lib/twilio-ruby/rest/notify/v1/credential.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CredentialPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/notify/v1/service.rb
+++ b/lib/twilio-ruby/rest/notify/v1/service.rb
@@ -155,7 +155,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/notify/v1/service/binding.rb
+++ b/lib/twilio-ruby/rest/notify/v1/service/binding.rb
@@ -182,7 +182,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               BindingPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle.rb
@@ -166,7 +166,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               BundlePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle/evaluation.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle/evaluation.rb
@@ -98,7 +98,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 EvaluationPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle/item_assignment.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle/item_assignment.rb
@@ -102,7 +102,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ItemAssignmentPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/end_user.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/end_user.rb
@@ -107,7 +107,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               EndUserPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/end_user_type.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/end_user_type.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               EndUserTypePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/regulation.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/regulation.rb
@@ -115,7 +115,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RegulationPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/supporting_document.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/supporting_document.rb
@@ -106,7 +106,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SupportingDocumentPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/supporting_document_type.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/supporting_document_type.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SupportingDocumentTypePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/bulk_exports/export/day.rb
+++ b/lib/twilio-ruby/rest/preview/bulk_exports/export/day.rb
@@ -106,7 +106,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DayPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/bulk_exports/export/export_custom_job.rb
+++ b/lib/twilio-ruby/rest/preview/bulk_exports/export/export_custom_job.rb
@@ -112,7 +112,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ExportCustomJobPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/deployed_devices/fleet.rb
+++ b/lib/twilio-ruby/rest/preview/deployed_devices/fleet.rb
@@ -100,7 +100,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             FleetPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/deployed_devices/fleet/certificate.rb
+++ b/lib/twilio-ruby/rest/preview/deployed_devices/fleet/certificate.rb
@@ -118,7 +118,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CertificatePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/deployed_devices/fleet/deployment.rb
+++ b/lib/twilio-ruby/rest/preview/deployed_devices/fleet/deployment.rb
@@ -106,7 +106,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DeploymentPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/deployed_devices/fleet/device.rb
+++ b/lib/twilio-ruby/rest/preview/deployed_devices/fleet/device.rb
@@ -124,7 +124,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DevicePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/deployed_devices/fleet/key.rb
+++ b/lib/twilio-ruby/rest/preview/deployed_devices/fleet/key.rb
@@ -112,7 +112,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               KeyPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document.rb
@@ -107,7 +107,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             AuthorizationDocumentPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document/dependent_hosted_number_order.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document/dependent_hosted_number_order.rb
@@ -149,7 +149,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DependentHostedNumberOrderPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/hosted_numbers/hosted_number_order.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers/hosted_number_order.rb
@@ -143,7 +143,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             HostedNumberOrderPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/marketplace/available_add_on.rb
+++ b/lib/twilio-ruby/rest/preview/marketplace/available_add_on.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             AvailableAddOnPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/marketplace/available_add_on/available_add_on_extension.rb
+++ b/lib/twilio-ruby/rest/preview/marketplace/available_add_on/available_add_on_extension.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AvailableAddOnExtensionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/marketplace/installed_add_on.rb
+++ b/lib/twilio-ruby/rest/preview/marketplace/installed_add_on.rb
@@ -110,7 +110,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             InstalledAddOnPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/marketplace/installed_add_on/installed_add_on_extension.rb
+++ b/lib/twilio-ruby/rest/preview/marketplace/installed_add_on/installed_add_on_extension.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               InstalledAddOnExtensionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/sync/service.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service.rb
@@ -107,7 +107,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/sync/service/document.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/document.rb
@@ -102,7 +102,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DocumentPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/sync/service/document/document_permission.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/document/document_permission.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 DocumentPermissionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/sync/service/sync_list.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/sync_list.rb
@@ -101,7 +101,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SyncListPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/sync/service/sync_list/sync_list_item.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/sync_list/sync_list_item.rb
@@ -120,7 +120,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncListItemPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/sync/service/sync_list/sync_list_permission.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/sync_list/sync_list_permission.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncListPermissionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/sync/service/sync_map.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/sync_map.rb
@@ -101,7 +101,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SyncMapPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/sync/service/sync_map/sync_map_item.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/sync_map/sync_map_item.rb
@@ -121,7 +121,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncMapItemPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/sync/service/sync_map/sync_map_permission.rb
+++ b/lib/twilio-ruby/rest/preview/sync/service/sync_map/sync_map_permission.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncMapPermissionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/trusted_comms/business/insights/impressions_rate.rb
+++ b/lib/twilio-ruby/rest/preview/trusted_comms/business/insights/impressions_rate.rb
@@ -109,7 +109,7 @@ module Twilio
                     'Interval' => interval,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 ImpressionsRateInstance.new(@version, payload, business_sid: @solution[:business_sid], )
               end

--- a/lib/twilio-ruby/rest/preview/understand/assistant.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             AssistantPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/field_type.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/field_type.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               FieldTypePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/field_type/field_value.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/field_type/field_value.rb
@@ -99,7 +99,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 FieldValuePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/model_build.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/model_build.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ModelBuildPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/query.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/query.rb
@@ -118,7 +118,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               QueryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/task.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/task.rb
@@ -89,7 +89,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               TaskPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/task/field.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/task/field.rb
@@ -91,7 +91,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 FieldPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/understand/assistant/task/sample.rb
+++ b/lib/twilio-ruby/rest/preview/understand/assistant/task/sample.rb
@@ -95,7 +95,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SamplePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/preview/wireless/command.rb
+++ b/lib/twilio-ruby/rest/preview/wireless/command.rb
@@ -116,7 +116,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CommandPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/wireless/rate_plan.rb
+++ b/lib/twilio-ruby/rest/preview/wireless/rate_plan.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             RatePlanPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/wireless/sim.rb
+++ b/lib/twilio-ruby/rest/preview/wireless/sim.rb
@@ -122,7 +122,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             SimPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/preview/wireless/sim/usage.rb
+++ b/lib/twilio-ruby/rest/preview/wireless/sim/usage.rb
@@ -88,7 +88,7 @@ module Twilio
             def fetch(end_: :unset, start: :unset)
               params = Twilio::Values.of({'End' => end_, 'Start' => start, })
 
-              payload = @version.fetch('GET', @uri, params)
+              payload = @version.fetch('GET', @uri, params: params)
 
               UsageInstance.new(@version, payload, sim_sid: @solution[:sim_sid], )
             end

--- a/lib/twilio-ruby/rest/pricing/v1/messaging/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v1/messaging/country.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CountryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/pricing/v1/phone_number/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v1/phone_number/country.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CountryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/pricing/v1/voice/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v1/voice/country.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CountryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/pricing/v2/voice/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v2/voice/country.rb
@@ -86,7 +86,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CountryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/pricing/v2/voice/number.rb
+++ b/lib/twilio-ruby/rest/pricing/v2/voice/number.rb
@@ -86,7 +86,7 @@ module Twilio
             def fetch(origination_number: :unset)
               params = Twilio::Values.of({'OriginationNumber' => origination_number, })
 
-              payload = @version.fetch('GET', @uri, params)
+              payload = @version.fetch('GET', @uri, params: params)
 
               NumberInstance.new(@version, payload, destination_number: @solution[:destination_number], )
             end

--- a/lib/twilio-ruby/rest/proxy/v1/service.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/proxy/v1/service/phone_number.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/phone_number.rb
@@ -111,7 +111,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               PhoneNumberPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/proxy/v1/service/session.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/session.rb
@@ -91,7 +91,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SessionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/proxy/v1/service/session/interaction.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/session/interaction.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 InteractionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/proxy/v1/service/session/participant.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/session/participant.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ParticipantPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/proxy/v1/service/session/participant/message_interaction.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/session/participant/message_interaction.rb
@@ -115,7 +115,7 @@ module Twilio
                       'PageSize' => page_size,
                   })
 
-                  response = @version.page('GET', @uri, params)
+                  response = @version.page('GET', @uri, params: params)
 
                   MessageInteractionPage.new(@version, response, @solution)
                 end

--- a/lib/twilio-ruby/rest/proxy/v1/service/short_code.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/short_code.rb
@@ -104,7 +104,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ShortCodePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/serverless/v1/service.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service.rb
@@ -87,7 +87,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/serverless/v1/service/asset.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/asset.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               AssetPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/serverless/v1/service/asset/asset_version.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/asset/asset_version.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 AssetVersionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/serverless/v1/service/build.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/build.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               BuildPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/serverless/v1/service/environment.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/environment.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               EnvironmentPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/serverless/v1/service/environment/deployment.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/environment/deployment.rb
@@ -92,7 +92,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 DeploymentPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/serverless/v1/service/environment/log.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/environment/log.rb
@@ -125,7 +125,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 LogPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/serverless/v1/service/environment/variable.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/environment/variable.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 VariablePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/serverless/v1/service/function.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/function.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               FunctionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/serverless/v1/service/function/function_version.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/function/function_version.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 FunctionVersionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/studio/v1/flow.rb
+++ b/lib/twilio-ruby/rest/studio/v1/flow.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             FlowPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/studio/v1/flow/engagement.rb
+++ b/lib/twilio-ruby/rest/studio/v1/flow/engagement.rb
@@ -87,7 +87,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               EngagementPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/studio/v1/flow/engagement/step.rb
+++ b/lib/twilio-ruby/rest/studio/v1/flow/engagement/step.rb
@@ -89,7 +89,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 StepPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/studio/v1/flow/execution.rb
+++ b/lib/twilio-ruby/rest/studio/v1/flow/execution.rb
@@ -116,7 +116,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ExecutionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/studio/v1/flow/execution/execution_step.rb
+++ b/lib/twilio-ruby/rest/studio/v1/flow/execution/execution_step.rb
@@ -89,7 +89,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ExecutionStepPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/studio/v2/flow.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow.rb
@@ -108,7 +108,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             FlowPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/studio/v2/flow/execution.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow/execution.rb
@@ -118,7 +118,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ExecutionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/studio/v2/flow/execution/execution_step.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow/execution/execution_step.rb
@@ -91,7 +91,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ExecutionStepPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/studio/v2/flow/flow_revision.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow/flow_revision.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               FlowRevisionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/supersim/v1/command.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/command.rb
@@ -150,7 +150,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CommandPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/supersim/v1/fleet.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/fleet.rb
@@ -141,7 +141,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             FleetPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/supersim/v1/network.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/network.rb
@@ -117,7 +117,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             NetworkPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/supersim/v1/network_access_profile.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/network_access_profile.rb
@@ -106,7 +106,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             NetworkAccessProfilePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/supersim/v1/network_access_profile/network_access_profile_network.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/network_access_profile/network_access_profile_network.rb
@@ -90,7 +90,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               NetworkAccessProfileNetworkPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/supersim/v1/sim.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/sim.rb
@@ -114,7 +114,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             SimPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/supersim/v1/usage_record.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/usage_record.rb
@@ -140,7 +140,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             UsageRecordPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/sync/v1/service.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service.rb
@@ -130,7 +130,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/sync/v1/service/document.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/document.rb
@@ -116,7 +116,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DocumentPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/sync/v1/service/document/document_permission.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/document/document_permission.rb
@@ -94,7 +94,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 DocumentPermissionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_list.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_list.rb
@@ -117,7 +117,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SyncListPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_list/sync_list_item.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_list/sync_list_item.rb
@@ -159,7 +159,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncListItemPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_list/sync_list_permission.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_list/sync_list_permission.rb
@@ -94,7 +94,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncListPermissionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_map.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_map.rb
@@ -116,7 +116,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SyncMapPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_map/sync_map_item.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_map/sync_map_item.rb
@@ -168,7 +168,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncMapItemPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_map/sync_map_permission.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_map/sync_map_permission.rb
@@ -93,7 +93,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SyncMapPermissionPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/sync/v1/service/sync_stream.rb
+++ b/lib/twilio-ruby/rest/sync/v1/service/sync_stream.rb
@@ -111,7 +111,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               SyncStreamPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace.rb
@@ -92,7 +92,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             WorkspacePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/activity.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/activity.rb
@@ -113,7 +113,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ActivityPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/event.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/event.rb
@@ -200,7 +200,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               EventPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task.rb
@@ -200,7 +200,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               TaskPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task/reservation.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task/reservation.rb
@@ -100,7 +100,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ReservationPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_channel.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_channel.rb
@@ -88,7 +88,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               TaskChannelPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue.rb
@@ -126,7 +126,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               TaskQueuePage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_cumulative_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_cumulative_statistics.rb
@@ -112,7 +112,7 @@ module Twilio
                     'SplitByWaitTime' => split_by_wait_time,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 TaskQueueCumulativeStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_real_time_statistics.rb
@@ -95,7 +95,7 @@ module Twilio
               def fetch(task_channel: :unset)
                 params = Twilio::Values.of({'TaskChannel' => task_channel, })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 TaskQueueRealTimeStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_statistics.rb
@@ -112,7 +112,7 @@ module Twilio
                     'SplitByWaitTime' => split_by_wait_time,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 TaskQueueStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queues_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queues_statistics.rb
@@ -160,7 +160,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 TaskQueuesStatisticsPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker.rb
@@ -164,7 +164,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               WorkerPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/reservation.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/reservation.rb
@@ -100,7 +100,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 ReservationPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/worker_channel.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/worker_channel.rb
@@ -91,7 +91,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 WorkerChannelPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/worker_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/worker_statistics.rb
@@ -108,7 +108,7 @@ module Twilio
                     'TaskChannel' => task_channel,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkerStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_cumulative_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_cumulative_statistics.rb
@@ -98,7 +98,7 @@ module Twilio
                     'TaskChannel' => task_channel,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkersCumulativeStatisticsInstance.new(@version, payload, workspace_sid: @solution[:workspace_sid], )
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_real_time_statistics.rb
@@ -86,7 +86,7 @@ module Twilio
               def fetch(task_channel: :unset)
                 params = Twilio::Values.of({'TaskChannel' => task_channel, })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkersRealTimeStatisticsInstance.new(@version, payload, workspace_sid: @solution[:workspace_sid], )
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_statistics.rb
@@ -106,7 +106,7 @@ module Twilio
                     'TaskChannel' => task_channel,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkersStatisticsInstance.new(@version, payload, workspace_sid: @solution[:workspace_sid], )
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow.rb
@@ -95,7 +95,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               WorkflowPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow/workflow_cumulative_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow/workflow_cumulative_statistics.rb
@@ -116,7 +116,7 @@ module Twilio
                     'SplitByWaitTime' => split_by_wait_time,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkflowCumulativeStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow/workflow_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow/workflow_real_time_statistics.rb
@@ -95,7 +95,7 @@ module Twilio
               def fetch(task_channel: :unset)
                 params = Twilio::Values.of({'TaskChannel' => task_channel, })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkflowRealTimeStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow/workflow_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workflow/workflow_statistics.rb
@@ -116,7 +116,7 @@ module Twilio
                     'SplitByWaitTime' => split_by_wait_time,
                 })
 
-                payload = @version.fetch('GET', @uri, params)
+                payload = @version.fetch('GET', @uri, params: params)
 
                 WorkflowStatisticsInstance.new(
                     @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_cumulative_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_cumulative_statistics.rb
@@ -108,7 +108,7 @@ module Twilio
                   'SplitByWaitTime' => split_by_wait_time,
               })
 
-              payload = @version.fetch('GET', @uri, params)
+              payload = @version.fetch('GET', @uri, params: params)
 
               WorkspaceCumulativeStatisticsInstance.new(
                   @version,

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_real_time_statistics.rb
@@ -83,7 +83,7 @@ module Twilio
             def fetch(task_channel: :unset)
               params = Twilio::Values.of({'TaskChannel' => task_channel, })
 
-              payload = @version.fetch('GET', @uri, params)
+              payload = @version.fetch('GET', @uri, params: params)
 
               WorkspaceRealTimeStatisticsInstance.new(@version, payload, workspace_sid: @solution[:workspace_sid], )
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_statistics.rb
@@ -104,7 +104,7 @@ module Twilio
                   'SplitByWaitTime' => split_by_wait_time,
               })
 
-              payload = @version.fetch('GET', @uri, params)
+              payload = @version.fetch('GET', @uri, params: params)
 
               WorkspaceStatisticsInstance.new(@version, payload, workspace_sid: @solution[:workspace_sid], )
             end

--- a/lib/twilio-ruby/rest/trunking/v1/trunk.rb
+++ b/lib/twilio-ruby/rest/trunking/v1/trunk.rb
@@ -137,7 +137,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             TrunkPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/trunking/v1/trunk/credential_list.rb
+++ b/lib/twilio-ruby/rest/trunking/v1/trunk/credential_list.rb
@@ -103,7 +103,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CredentialListPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/trunking/v1/trunk/ip_access_control_list.rb
+++ b/lib/twilio-ruby/rest/trunking/v1/trunk/ip_access_control_list.rb
@@ -100,7 +100,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               IpAccessControlListPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/trunking/v1/trunk/origination_url.rb
+++ b/lib/twilio-ruby/rest/trunking/v1/trunk/origination_url.rb
@@ -116,7 +116,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               OriginationUrlPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/trunking/v1/trunk/phone_number.rb
+++ b/lib/twilio-ruby/rest/trunking/v1/trunk/phone_number.rb
@@ -103,7 +103,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               PhoneNumberPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/verify/v2/service.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service.rb
@@ -133,7 +133,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ServicePage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/verify/v2/service/entity.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/entity.rb
@@ -108,7 +108,7 @@ module Twilio
               })
               headers = Twilio::Values.of({'Twilio-Sandbox-Mode' => twilio_sandbox_mode, })
 
-              response = @version.page('GET', @uri, params, headers: headers)
+              response = @version.page('GET', @uri, params: params, headers: headers)
 
               EntityPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/verify/v2/service/entity/challenge.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/entity/challenge.rb
@@ -148,7 +148,7 @@ module Twilio
                 })
                 headers = Twilio::Values.of({'Twilio-Sandbox-Mode' => twilio_sandbox_mode, })
 
-                response = @version.page('GET', @uri, params, headers: headers)
+                response = @version.page('GET', @uri, params: params, headers: headers)
 
                 ChallengePage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/verify/v2/service/entity/factor.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/entity/factor.rb
@@ -134,7 +134,7 @@ module Twilio
                 })
                 headers = Twilio::Values.of({'Twilio-Sandbox-Mode' => twilio_sandbox_mode, })
 
-                response = @version.page('GET', @uri, params, headers: headers)
+                response = @version.page('GET', @uri, params: params, headers: headers)
 
                 FactorPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/verify/v2/service/messaging_configuration.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/messaging_configuration.rb
@@ -107,7 +107,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               MessagingConfigurationPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/verify/v2/service/rate_limit.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/rate_limit.rb
@@ -104,7 +104,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RateLimitPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/verify/v2/service/rate_limit/bucket.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/rate_limit/bucket.rb
@@ -111,7 +111,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 BucketPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/verify/v2/service/webhook.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/webhook.rb
@@ -113,7 +113,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               WebhookPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/video/v1/composition.rb
+++ b/lib/twilio-ruby/rest/video/v1/composition.rb
@@ -128,7 +128,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CompositionPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/video/v1/composition_hook.rb
+++ b/lib/twilio-ruby/rest/video/v1/composition_hook.rb
@@ -137,7 +137,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CompositionHookPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/video/v1/recording.rb
+++ b/lib/twilio-ruby/rest/video/v1/recording.rb
@@ -147,7 +147,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             RecordingPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/video/v1/room.rb
+++ b/lib/twilio-ruby/rest/video/v1/room.rb
@@ -176,7 +176,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             RoomPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/video/v1/room/recording.rb
+++ b/lib/twilio-ruby/rest/video/v1/room/recording.rb
@@ -126,7 +126,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               RoomRecordingPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/video/v1/room/room_participant.rb
+++ b/lib/twilio-ruby/rest/video/v1/room/room_participant.rb
@@ -134,7 +134,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ParticipantPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/video/v1/room/room_participant/room_participant_published_track.rb
+++ b/lib/twilio-ruby/rest/video/v1/room/room_participant/room_participant_published_track.rb
@@ -91,7 +91,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 PublishedTrackPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/video/v1/room/room_participant/room_participant_subscribed_track.rb
+++ b/lib/twilio-ruby/rest/video/v1/room/room_participant/room_participant_subscribed_track.rb
@@ -90,7 +90,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 SubscribedTrackPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/voice/v1/byoc_trunk.rb
+++ b/lib/twilio-ruby/rest/voice/v1/byoc_trunk.rb
@@ -134,7 +134,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ByocTrunkPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/voice/v1/connection_policy.rb
+++ b/lib/twilio-ruby/rest/voice/v1/connection_policy.rb
@@ -98,7 +98,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             ConnectionPolicyPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/voice/v1/connection_policy/connection_policy_target.rb
+++ b/lib/twilio-ruby/rest/voice/v1/connection_policy/connection_policy_target.rb
@@ -122,7 +122,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               ConnectionPolicyTargetPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/voice/v1/dialing_permissions/country.rb
+++ b/lib/twilio-ruby/rest/voice/v1/dialing_permissions/country.rb
@@ -159,7 +159,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               CountryPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/voice/v1/dialing_permissions/country/highrisk_special_prefix.rb
+++ b/lib/twilio-ruby/rest/voice/v1/dialing_permissions/country/highrisk_special_prefix.rb
@@ -91,7 +91,7 @@ module Twilio
                     'PageSize' => page_size,
                 })
 
-                response = @version.page('GET', @uri, params)
+                response = @version.page('GET', @uri, params: params)
 
                 HighriskSpecialPrefixPage.new(@version, response, @solution)
               end

--- a/lib/twilio-ruby/rest/voice/v1/ip_record.rb
+++ b/lib/twilio-ruby/rest/voice/v1/ip_record.rb
@@ -106,7 +106,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             IpRecordPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/voice/v1/source_ip_mapping.rb
+++ b/lib/twilio-ruby/rest/voice/v1/source_ip_mapping.rb
@@ -100,7 +100,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             SourceIpMappingPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/wireless/v1/command.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/command.rb
@@ -126,7 +126,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             CommandPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/wireless/v1/rate_plan.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/rate_plan.rb
@@ -85,7 +85,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             RatePlanPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/wireless/v1/sim.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/sim.rb
@@ -132,7 +132,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             SimPage.new(@version, response, @solution)
           end

--- a/lib/twilio-ruby/rest/wireless/v1/sim/data_session.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/sim/data_session.rb
@@ -103,7 +103,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               DataSessionPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/wireless/v1/sim/usage_record.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/sim/usage_record.rb
@@ -125,7 +125,7 @@ module Twilio
                   'PageSize' => page_size,
               })
 
-              response = @version.page('GET', @uri, params)
+              response = @version.page('GET', @uri, params: params)
 
               UsageRecordPage.new(@version, response, @solution)
             end

--- a/lib/twilio-ruby/rest/wireless/v1/usage_record.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/usage_record.rb
@@ -115,7 +115,7 @@ module Twilio
                 'PageSize' => page_size,
             })
 
-            response = @version.page('GET', @uri, params)
+            response = @version.page('GET', @uri, params: params)
 
             UsageRecordPage.new(@version, response, @solution)
           end

--- a/spec/framework/version_spec.rb
+++ b/spec/framework/version_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+
+describe 'Version Action Methods' do
+  it 'receives fetch responses' do
+    @holodeck.mock(
+      Twilio::Response.new(
+        200,
+        '{
+            "caller_name": null,
+            "carrier": null,
+            "fraud": null,
+            "add_ons": null,
+            "country_code": "US",
+            "national_format": "(510) 867-5310",
+            "phone_number": "+15108675310",
+            "url": "https://lookups.twilio.com/v1/PhoneNumbers/+15108675310"
+          }'
+      )
+    )
+    actual = @client.lookups.v1.phone_numbers('+15017122661').fetch(type: 'sms')
+    expect(actual).to_not eq(nil)
+  end
+
+  it 'receives create responses' do
+    @holodeck.mock(
+      Twilio::Response.new(
+        201,
+        '{
+          "auth_token": "auth_token",
+          "date_created": "Thu, 30 Jul 2015 20:00:00 +0000",
+          "date_updated": "Thu, 30 Jul 2015 20:00:00 +0000",
+          "friendly_name": "friendly_name",
+          "owner_account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "status": "active",
+          "subresource_uris": {
+              "available_phone_numbers": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers.json",
+              "calls": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls.json",
+              "conferences": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences.json",
+              "incoming_phone_numbers": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json",
+              "notifications": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications.json",
+              "outgoing_caller_ids": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds.json",
+              "recordings": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings.json",
+              "transcriptions": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions.json",
+              "addresses": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses.json",
+              "signing_keys": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys.json",
+              "connect_apps": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/ConnectApps.json",
+              "sip": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP.json",
+              "authorized_connect_apps": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AuthorizedConnectApps.json",
+              "usage": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage.json",
+              "keys": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys.json",
+              "applications": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications.json",
+              "short_codes": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SMS/ShortCodes.json",
+              "queues": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues.json",
+              "messages": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages.json",
+              "balance": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Balance.json"
+          },
+          "type": "Full",
+          "uri": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"
+        }'
+      )
+    )
+    actual = @client.api.v2010.accounts.create(friendly_name: 'friendly_name')
+    expect(actual).to_not eq(nil)
+  end
+
+  it 'receives update responses' do
+    @holodeck.mock(
+      Twilio::Response.new(
+        200,
+        '{
+          "auth_token": "auth_token",
+          "date_created": "Thu, 30 Jul 2015 20:00:00 +0000",
+          "date_updated": "Thu, 30 Jul 2015 20:00:00 +0000",
+          "friendly_name": "friendly_name",
+          "owner_account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "status": "active",
+          "subresource_uris": {
+              "available_phone_numbers": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers.json",
+              "calls": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls.json",
+              "conferences": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences.json",
+              "incoming_phone_numbers": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json",
+              "notifications": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications.json",
+              "outgoing_caller_ids": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds.json",
+              "recordings": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings.json",
+              "transcriptions": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions.json",
+              "addresses": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses.json",
+              "signing_keys": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys.json",
+              "connect_apps": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/ConnectApps.json",
+              "sip": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP.json",
+              "authorized_connect_apps": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AuthorizedConnectApps.json",
+              "usage": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage.json",
+              "keys": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys.json",
+              "applications": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications.json",
+              "short_codes": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SMS/ShortCodes.json",
+              "queues": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues.json",
+              "messages": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages.json",
+              "balance": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Balance.json"
+          },
+          "type": "Full",
+          "uri": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"
+        }'
+      )
+    )
+    actual = @client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(friendly_name: 'friendly_name')
+    expect(actual).to_not eq(nil)
+  end
+
+  it 'receives read_full responses' do
+    @holodeck.mock(
+      Twilio::Response.new(
+        200,
+        '{
+          "first_page_uri": "/2010-04-01/Accounts.json?FriendlyName=friendly_name&Status=active&PageSize=50&Page=0",
+          "end": 0,
+          "previous_page_uri": null,
+          "accounts": [
+              {
+                  "auth_token": "auth_token",
+                  "date_created": "Thu, 30 Jul 2015 20:00:00 +0000",
+                  "date_updated": "Thu, 30 Jul 2015 20:00:00 +0000",
+                  "friendly_name": "friendly_name",
+                  "owner_account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                  "status": "active",
+                  "subresource_uris": {
+                      "available_phone_numbers": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AvailablePhoneNumbers.json",
+                      "calls": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Calls.json",
+                      "conferences": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Conferences.json",
+                      "incoming_phone_numbers": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json",
+                      "notifications": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Notifications.json",
+                      "outgoing_caller_ids": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/OutgoingCallerIds.json",
+                      "recordings": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Recordings.json",
+                      "transcriptions": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Transcriptions.json",
+                      "addresses": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Addresses.json",
+                      "signing_keys": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SigningKeys.json",
+                      "connect_apps": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/ConnectApps.json",
+                      "sip": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SIP.json",
+                      "authorized_connect_apps": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/AuthorizedConnectApps.json",
+                      "usage": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Usage.json",
+                      "keys": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Keys.json",
+                      "applications": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Applications.json",
+                      "short_codes": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/SMS/ShortCodes.json",
+                      "queues": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Queues.json",
+                      "messages": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Messages.json",
+                      "balance": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Balance.json"
+                  },
+                  "type": "Full",
+                  "uri": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.json"
+              }
+            ],
+            "uri": "/2010-04-01/Accounts.json?FriendlyName=friendly_name&Status=active&PageSize=50&Page=0",
+            "page_size": 50,
+            "start": 0,
+            "next_page_uri": null,
+            "page": 0
+        }'
+      )
+    )
+
+    actual = @client.api.v2010.accounts.list(friendly_name: 'friendly_name')
+
+    expect(actual).to_not eq(nil)
+  end
+end


### PR DESCRIPTION
Fixes #518 