### PR TITLE
fix: drop the page limit calculation

### DIFF
--- a/lib/twilio-ruby/framework/version.rb
+++ b/lib/twilio-ruby/framework/version.rb
@@ -112,18 +112,13 @@ module Twilio
       end
 
       def read_limits(limit = nil, page_size = nil)
-        page_limit = nil
-
-        unless limit.nil?
-          # If there is no user-specified page_size, pick the most network efficient size
+        unless limit.nil? || page_size
           page_size = limit
-          page_limit = (limit / page_size.to_f).ceil
         end
 
         {
           limit: limit || nil,
-          page_size: page_size || nil,
-          page_limit: page_limit
+          page_size: page_size || nil
         }
       end
 

--- a/spec/framework/version_spec.rb
+++ b/spec/framework/version_spec.rb
@@ -21,6 +21,48 @@ describe 'Version Action Methods' do
     expect(actual).to_not eq(nil)
   end
 
+  describe 'stream' do
+    before(:each) do
+      @holodeck.mock(
+        Twilio::Response.new(
+          200,
+          '{
+            "next_page_uri": "/2010-04-01/Accounts/AC123/Messages.json?Page=1",
+            "messages": [{"body": "payload0"}, {"body": "payload1"}]
+          }'
+        )
+      )
+      @holodeck.mock(
+        Twilio::Response.new(
+          200,
+          '{
+            "next_page_uri": "/2010-04-01/Accounts/AC123/Messages.json?Page=2",
+            "messages": [{"body": "payload2"}, {"body": "payload3"}]
+          }'
+        )
+      )
+      @holodeck.mock(
+        Twilio::Response.new(
+          200,
+          '{
+            "next_page_uri": null,
+            "messages": [{"body": "payload4"}]
+          }'
+        )
+      )
+    end
+
+    it 'streams all results' do
+      actual = @client.messages.stream
+      expect(actual.count).to eq(5)
+    end
+
+    it 'limits results' do
+      actual = @client.messages.stream(limit: 3)
+      expect(actual.count).to eq(3)
+    end
+  end
+
   it 'receives create responses' do
     @holodeck.mock(
       Twilio::Response.new(

--- a/spec/holodeck/holodeck.rb
+++ b/spec/holodeck/holodeck.rb
@@ -40,12 +40,12 @@ class Holodeck
   ANY = Request.new(any: true)
 
   def initialize
-    @response = nil
+    @responses = []
     @requests = []
   end
 
   def mock(response)
-    @response = response
+    @responses << response
   end
 
   def request(host, port, method, url, params = {}, data = {}, headers = {}, auth = nil, _timeout = nil)
@@ -57,7 +57,7 @@ class Holodeck
       headers: headers,
       auth: auth
     )
-    @response
+    @responses.shift
   end
 
   def has_request?(request)


### PR DESCRIPTION
Dropping the page limit calculation since it doesn't make sense to be calculated from a record limit.

Relates to https://github.com/twilio/twilio-python/pull/523