### PR TITLE
fix: allow API redirect responses

### DIFF
--- a/lib/twilio-ruby/framework/version.rb
+++ b/lib/twilio-ruby/framework/version.rb
@@ -68,7 +68,8 @@ module Twilio
           timeout
         )
 
-        if response.status_code < 200 || response.status_code >= 300
+        # Note that 3XX response codes are allowed for fetches.
+        if response.status_code < 200 || response.status_code >= 400
           raise exception(response, 'Unable to fetch record')
         end
 

--- a/spec/framework/version_spec.rb
+++ b/spec/framework/version_spec.rb
@@ -21,6 +21,17 @@ describe 'Version Action Methods' do
     expect(actual).to_not eq(nil)
   end
 
+  it 'handles redirect fetch responses' do
+    @holodeck.mock(
+      Twilio::Response.new(
+        307,
+        '{"phone_number": "+15108675310"}'
+      )
+    )
+    actual = @client.lookups.v1.phone_numbers('+15017122661').fetch
+    expect(actual).to_not eq(nil)
+  end
+
   describe 'stream' do
     before(:each) do
       @holodeck.mock(


### PR DESCRIPTION
Fetching a BulkExport for a single day returns a `307` with the AWS URL for the file. With this change, the URL will now be included in the response.

Fixes https://github.com/twilio/twilio-ruby/issues/532