### PR TITLE
feat: Add region to AccessToken

### DIFF
--- a/lib/twilio-ruby/jwt/access_token.rb
+++ b/lib/twilio-ruby/jwt/access_token.rb
@@ -20,7 +20,8 @@ module Twilio
                     :grants,
                     :nbf,
                     :ttl,
-                    :valid_until
+                    :valid_until,
+                    :region
 
       def initialize(
         account_sid,
@@ -30,7 +31,8 @@ module Twilio
         identity: nil,
         nbf: nil,
         ttl: 3600,
-        valid_until: nil
+        valid_until: nil,
+        region: nil
       )
         super(secret_key: secret,
               issuer: signing_key_sid,
@@ -46,6 +48,7 @@ module Twilio
         @grants = grants
         @ttl = ttl
         @valid_until = valid_until
+        @region = region
       end
 
       def add_grant(grant)
@@ -75,6 +78,8 @@ module Twilio
         headers = {
           cty: 'twilio-fpa;v=1'
         }
+
+        headers[:twr] = region unless region&.nil?
 
         headers
       end

--- a/spec/jwt/access_token_spec.rb
+++ b/spec/jwt/access_token_spec.rb
@@ -14,10 +14,18 @@ describe Twilio::JWT::AccessToken do
       expect(payload['grants'].count).to eq(0)
     end
 
-    it 'should add the proper headers' do
+    it 'should add the proper headers without region' do
       scat = Twilio::JWT::AccessToken.new 'AC123', 'SK123', 'secret'
       _, headers = JWT.decode scat.to_s, 'secret'
       expect(headers['cty']).to eq('twilio-fpa;v=1')
+      expect(headers['twr']).to be_nil
+    end
+
+    it 'should add the proper headers with region' do
+      scat = Twilio::JWT::AccessToken.new 'AC123', 'SK123', 'secret', region: 'foo'
+      _, headers = JWT.decode scat.to_s, 'secret'
+      expect(headers['cty']).to eq('twilio-fpa;v=1')
+      expect(headers['twr']).to eq('foo')
     end
 
     it 'identity should exist in the grants' do


### PR DESCRIPTION
# Feature #

This PR adds AccessTokenOptions.region parameter to support regional authentication. This value will be encoded in the twr header of the JWT. If the parameter is not specified or invalid, no twr value is added. See this document for more details.
JIRA: https://issues.corp.twilio.com/browse/CLIENT-8142

I was unable to find any existing documentation for the file I modified. Please point me to the right file to make documentation changes, if a place exists.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified