### PR TITLE
fix: Adds Ruby 3.0 to Travis. Fixes test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ bundler_args: --without development
 
 rvm:
   - ruby-head
+  - 3.0
   - 2.7
   - 2.6
   - 2.5

--- a/spec/twiml/voice_response_spec.rb
+++ b/spec/twiml/voice_response_spec.rb
@@ -575,7 +575,7 @@ describe Twilio::TwiML::VoiceResponse do
         </Response>
       XML
       enqueue_elem = Twilio::TwiML::Enqueue.new(name: nil, workflow_sid: '123123123')
-      enqueue_elem.task(account_sid: 'AC123123123')
+      enqueue_elem.task({ account_sid: 'AC123123123' })
 
       response = Twilio::TwiML::VoiceResponse.new
       response.append(enqueue_elem)


### PR DESCRIPTION
The code is correct in the `VoiceResponse`, but the test is wrong. The body of a task is a JSON object, so the argument should be a hash. Originally this was implemented, in the test, as a hash omitting the curly braces, however Ruby 3 is more strict about how hashes and keyword arguments work together. To submit the body as a hash, you can no longer omit the braces. Once that was fixed, the tests all pass under Ruby 3.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
