### PR TITLE
Fixing docs for list parameter types

### DIFF
--- a/lib/twilio-ruby/rest/api/v2010/account/authorized_connect_app.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/authorized_connect_app.rb
@@ -288,7 +288,7 @@ module Twilio
             end
 
             ##
-            # @return [authorized_connect_app.Permission] Permissions authorized to the app
+            # @return [Array[authorized_connect_app.Permission]] Permissions authorized to the app
             def permissions
               @properties['permissions']
             end

--- a/lib/twilio-ruby/rest/api/v2010/account/call.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call.rb
@@ -52,10 +52,10 @@ module Twilio
             #   `status_callback_event` is specified, we will send the `completed` status. If an
             #   `application_sid` parameter is present, this parameter is ignored. URLs must
             #   contain a valid hostname (underscores are not permitted).
-            # @param [String] status_callback_event The call progress events that we will send
-            #   to the `status_callback` URL. Can be: `initiated`, `ringing`, `answered`, and
-            #   `completed`. If no event is specified, we send the `completed` status. If you
-            #   want to receive multiple events, specify each one in a separate
+            # @param [Array[String]] status_callback_event The call progress events that we
+            #   will send to the `status_callback` URL. Can be: `initiated`, `ringing`,
+            #   `answered`, and `completed`. If no event is specified, we send the `completed`
+            #   status. If you want to receive multiple events, specify each one in a separate
             #   `status_callback_event` parameter. See the code sample for {monitoring call
             #   progress}[https://www.twilio.com/docs/voice/api/call-resource?code-sample=code-create-a-call-resource-and-specify-a-statuscallbackevent&code-sdk-version=json].
             #   If an `application_sid` is present, this parameter is ignored.
@@ -106,10 +106,10 @@ module Twilio
             # @param [String] machine_detection_timeout The number of seconds that we should
             #   attempt to detect an answering machine before timing out and sending a voice
             #   request with `AnsweredBy` of `unknown`. The default timeout is 30 seconds.
-            # @param [String] recording_status_callback_event The recording status events that
-            #   will trigger calls to the URL specified in `recording_status_callback`. Can be:
-            #   `in-progress`, `completed` and `absent`. Defaults to `completed`. Separate
-            #   multiple values with a space.
+            # @param [Array[String]] recording_status_callback_event The recording status
+            #   events that will trigger calls to the URL specified in
+            #   `recording_status_callback`. Can be: `in-progress`, `completed` and `absent`.
+            #   Defaults to `completed`. Separate  multiple values with a space.
             # @param [String] trim Whether to trim any leading and trailing silence from the
             #   recording. Can be: `trim-silence` or `do-not-trim` and the default is
             #   `trim-silence`.

--- a/lib/twilio-ruby/rest/api/v2010/account/call/feedback.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call/feedback.rb
@@ -92,8 +92,8 @@ module Twilio
               # @param [String] quality_score The call quality expressed as an integer from `1`
               #   to `5` where `1` represents very poor call quality and `5` represents a perfect
               #   call.
-              # @param [feedback.Issues] issue A list of one or more issues experienced during
-              #   the call. Issues can be: `imperfect-audio`, `dropped-call`,
+              # @param [Array[feedback.Issues]] issue A list of one or more issues experienced
+              #   during the call. Issues can be: `imperfect-audio`, `dropped-call`,
               #   `incorrect-caller-id`, `post-dial-delay`, `digits-not-captured`,
               #   `audio-latency`, `unsolicited-call`, or `one-way-audio`.
               # @return [FeedbackInstance] Created FeedbackInstance
@@ -132,10 +132,10 @@ module Twilio
               # @param [String] quality_score The call quality expressed as an integer from `1`
               #   to `5` where `1` represents very poor call quality and `5` represents a perfect
               #   call.
-              # @param [feedback.Issues] issue One or more issues experienced during the call.
-              #   The issues can be: `imperfect-audio`, `dropped-call`, `incorrect-caller-id`,
-              #   `post-dial-delay`, `digits-not-captured`, `audio-latency`, `unsolicited-call`,
-              #   or `one-way-audio`.
+              # @param [Array[feedback.Issues]] issue One or more issues experienced during the
+              #   call. The issues can be: `imperfect-audio`, `dropped-call`,
+              #   `incorrect-caller-id`, `post-dial-delay`, `digits-not-captured`,
+              #   `audio-latency`, `unsolicited-call`, or `one-way-audio`.
               # @return [FeedbackInstance] Updated FeedbackInstance
               def update(quality_score: nil, issue: :unset)
                 data = Twilio::Values.of({
@@ -227,7 +227,7 @@ module Twilio
               end
 
               ##
-              # @return [feedback.Issues] Issues experienced during the call
+              # @return [Array[feedback.Issues]] Issues experienced during the call
               def issues
                 @properties['issues']
               end
@@ -249,8 +249,8 @@ module Twilio
               # @param [String] quality_score The call quality expressed as an integer from `1`
               #   to `5` where `1` represents very poor call quality and `5` represents a perfect
               #   call.
-              # @param [feedback.Issues] issue A list of one or more issues experienced during
-              #   the call. Issues can be: `imperfect-audio`, `dropped-call`,
+              # @param [Array[feedback.Issues]] issue A list of one or more issues experienced
+              #   during the call. Issues can be: `imperfect-audio`, `dropped-call`,
               #   `incorrect-caller-id`, `post-dial-delay`, `digits-not-captured`,
               #   `audio-latency`, `unsolicited-call`, or `one-way-audio`.
               # @return [FeedbackInstance] Created FeedbackInstance
@@ -270,10 +270,10 @@ module Twilio
               # @param [String] quality_score The call quality expressed as an integer from `1`
               #   to `5` where `1` represents very poor call quality and `5` represents a perfect
               #   call.
-              # @param [feedback.Issues] issue One or more issues experienced during the call.
-              #   The issues can be: `imperfect-audio`, `dropped-call`, `incorrect-caller-id`,
-              #   `post-dial-delay`, `digits-not-captured`, `audio-latency`, `unsolicited-call`,
-              #   or `one-way-audio`.
+              # @param [Array[feedback.Issues]] issue One or more issues experienced during the
+              #   call. The issues can be: `imperfect-audio`, `dropped-call`,
+              #   `incorrect-caller-id`, `post-dial-delay`, `digits-not-captured`,
+              #   `audio-latency`, `unsolicited-call`, or `one-way-audio`.
               # @return [FeedbackInstance] Updated FeedbackInstance
               def update(quality_score: nil, issue: :unset)
                 context.update(quality_score: quality_score, issue: issue, )

--- a/lib/twilio-ruby/rest/api/v2010/account/call/feedback_summary.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call/feedback_summary.rb
@@ -237,7 +237,7 @@ module Twilio
               end
 
               ##
-              # @return [String] Issues experienced during the call
+              # @return [Array[String]] Issues experienced during the call
               def issues
                 @properties['issues']
               end

--- a/lib/twilio-ruby/rest/api/v2010/account/call/recording.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/call/recording.rb
@@ -33,10 +33,10 @@ module Twilio
 
               ##
               # Create the RecordingInstance
-              # @param [String] recording_status_callback_event The recording status events on
-              #   which we should call the `recording_status_callback` URL. Can be: `in-progress`,
-              #   `completed` and `absent` and the default is `completed`. Separate multiple event
-              #   values with a space.
+              # @param [Array[String]] recording_status_callback_event The recording status
+              #   events on which we should call the `recording_status_callback` URL. Can be:
+              #   `in-progress`, `completed` and `absent` and the default is `completed`. Separate
+              #   multiple event values with a space.
               # @param [String] recording_status_callback The URL we should call using the
               #   `recording_status_callback_method` on each recording event specified in
               #   `recording_status_callback_event`. For more information, see

--- a/lib/twilio-ruby/rest/api/v2010/account/conference/participant.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/conference/participant.rb
@@ -52,8 +52,8 @@ module Twilio
               #   `status_callback_method` to send status information to your application.
               # @param [String] status_callback_method The HTTP method we should use to call
               #   `status_callback`. Can be: `GET` and `POST` and defaults to `POST`.
-              # @param [String] status_callback_event The conference state changes that should
-              #   generate a call to `status_callback`. Can be: `initiated`, `ringing`,
+              # @param [Array[String]] status_callback_event The conference state changes that
+              #   should generate a call to `status_callback`. Can be: `initiated`, `ringing`,
               #   `answered`, and `completed`. Separate multiple values with a space. The default
               #   value is `completed`.
               # @param [String] label A label for this participant. If one is supplied, it may
@@ -105,10 +105,10 @@ module Twilio
               # @param [String] conference_status_callback_method The HTTP method we should use
               #   to call `conference_status_callback`. Can be: `GET` or `POST` and defaults to
               #   `POST`.
-              # @param [String] conference_status_callback_event The conference state changes
-              #   that should generate a call to `conference_status_callback`. Can be: `start`,
-              #   `end`, `join`, `leave`, `mute`, `hold`, and `speaker`. Separate multiple values
-              #   with a space. Defaults to `start end`.
+              # @param [Array[String]] conference_status_callback_event The conference state
+              #   changes that should generate a call to `conference_status_callback`. Can be:
+              #   `start`, `end`, `join`, `leave`, `mute`, `hold`, and `speaker`. Separate
+              #   multiple values with a space. Defaults to `start end`.
               # @param [String] recording_channels The recording channels for the final
               #   recording. Can be: `mono` or `dual` and the default is `mono`.
               # @param [String] recording_status_callback The URL that we should call using the
@@ -128,11 +128,11 @@ module Twilio
               # @param [String] conference_recording_status_callback_method The HTTP method we
               #   should use to call `conference_recording_status_callback`. Can be: `GET` or
               #   `POST` and defaults to `POST`.
-              # @param [String] recording_status_callback_event The recording state changes that
-              #   should generate a call to `recording_status_callback`. Can be: `in-progress`,
-              #   `completed`, and `failed`. Separate multiple values with a space. The default
-              #   value is `in-progress completed failed`.
-              # @param [String] conference_recording_status_callback_event The conference
+              # @param [Array[String]] recording_status_callback_event The recording state
+              #   changes that should generate a call to `recording_status_callback`. Can be:
+              #   `in-progress`, `completed`, and `failed`. Separate multiple values with a space.
+              #   The default value is `in-progress completed failed`.
+              # @param [Array[String]] conference_recording_status_callback_event The conference
               #   recording state changes that generate a call to
               #   `conference_recording_status_callback`. Can be: `in-progress`, `completed`, and
               #   `failed`. Separate multiple values with a space. The default value is

--- a/lib/twilio-ruby/rest/api/v2010/account/connect_app.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/connect_app.rb
@@ -189,7 +189,7 @@ module Twilio
             #   the resource. It can be up to 64 characters long.
             # @param [String] homepage_url A public URL where users can obtain more
             #   information about this Connect App.
-            # @param [connect_app.Permission] permissions A comma-separated list of the
+            # @param [Array[connect_app.Permission]] permissions A comma-separated list of the
             #   permissions you will request from the users of this ConnectApp.  Can include:
             #   `get-all` and `post-all`.
             # @return [ConnectAppInstance] Updated ConnectAppInstance
@@ -331,7 +331,7 @@ module Twilio
             end
 
             ##
-            # @return [connect_app.Permission] The set of permissions that your ConnectApp requests
+            # @return [Array[connect_app.Permission]] The set of permissions that your ConnectApp requests
             def permissions
               @properties['permissions']
             end
@@ -369,7 +369,7 @@ module Twilio
             #   the resource. It can be up to 64 characters long.
             # @param [String] homepage_url A public URL where users can obtain more
             #   information about this Connect App.
-            # @param [connect_app.Permission] permissions A comma-separated list of the
+            # @param [Array[connect_app.Permission]] permissions A comma-separated list of the
             #   permissions you will request from the users of this ConnectApp.  Can include:
             #   `get-all` and `post-all`.
             # @return [ConnectAppInstance] Updated ConnectAppInstance

--- a/lib/twilio-ruby/rest/api/v2010/account/message.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/message.rb
@@ -77,7 +77,7 @@ module Twilio
             #   can be stored or obfuscated based on privacy settings
             # @param [Boolean] smart_encoded Whether to detect Unicode characters that have a
             #   similar GSM-7 character and replace them. Can be: `true` or `false`.
-            # @param [String] persistent_action Rich actions for Channels Messages.
+            # @param [Array[String]] persistent_action Rich actions for Channels Messages.
             # @param [String] from A Twilio phone number in
             #   {E.164}[https://www.twilio.com/docs/glossary/what-e164] format, an {alphanumeric
             #   sender
@@ -99,10 +99,10 @@ module Twilio
             #   delivery.
             # @param [String] body The text of the message you want to send. Can be up to
             #   1,600 characters in length.
-            # @param [String] media_url The URL of the media to send with the message. The
-            #   media can be of type `gif`, `png`, and `jpeg` and will be formatted correctly on
-            #   the recipient's device. The media size limit is 5MB for supported file types
-            #   (JPEG, PNG, GIF) and 500KB for {other
+            # @param [Array[String]] media_url The URL of the media to send with the message.
+            #   The media can be of type `gif`, `png`, and `jpeg` and will be formatted
+            #   correctly on the recipient's device. The media size limit is 5MB for supported
+            #   file types (JPEG, PNG, GIF) and 500KB for {other
             #   types}[https://www.twilio.com/docs/sms/accepted-mime-types] of accepted media.
             #   To send more than one image in the message body, provide multiple `media_url`
             #   parameters in the POST request. You can include up to 10 `media_url` parameters

--- a/lib/twilio-ruby/rest/api/v2010/account/token.rb
+++ b/lib/twilio-ruby/rest/api/v2010/account/token.rb
@@ -119,7 +119,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array representing the ephemeral credentials
+            # @return [Array[String]] An array representing the ephemeral credentials
             def ice_servers
               @properties['ice_servers']
             end

--- a/lib/twilio-ruby/rest/chat/v1/service.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service.rb
@@ -246,8 +246,8 @@ module Twilio
           #   `pre_webhook_url` and `post_webhook_url` webhooks.  Can be: `POST` or `GET` and
           #   the default is `POST`. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
-          # @param [String] webhook_filters The list of WebHook events that are enabled for
-          #   this Service instance. See {Webhook
+          # @param [Array[String]] webhook_filters The list of WebHook events that are
+          #   enabled for this Service instance. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
           # @param [String] webhooks_on_message_send_url The URL of the webhook to call in
           #   response to the `on_message_send` event using the
@@ -621,7 +621,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The list of WebHook events that are enabled for this Service instance
+          # @return [Array[String]] The list of WebHook events that are enabled for this Service instance
           def webhook_filters
             @properties['webhook_filters']
           end
@@ -716,8 +716,8 @@ module Twilio
           #   `pre_webhook_url` and `post_webhook_url` webhooks.  Can be: `POST` or `GET` and
           #   the default is `POST`. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
-          # @param [String] webhook_filters The list of WebHook events that are enabled for
-          #   this Service instance. See {Webhook
+          # @param [Array[String]] webhook_filters The list of WebHook events that are
+          #   enabled for this Service instance. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
           # @param [String] webhooks_on_message_send_url The URL of the webhook to call in
           #   response to the `on_message_send` event using the

--- a/lib/twilio-ruby/rest/chat/v1/service/channel.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel.rb
@@ -57,8 +57,8 @@ module Twilio
             # Lists ChannelInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [channel.ChannelType] type The visibility of the Channels to read. Can
-            #   be: `public` or `private` and defaults to `public`.
+            # @param [Array[channel.ChannelType]] type The visibility of the Channels to read.
+            #   Can be: `public` or `private` and defaults to `public`.
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit.  Default is no limit
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -74,8 +74,8 @@ module Twilio
             # Streams ChannelInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [channel.ChannelType] type The visibility of the Channels to read. Can
-            #   be: `public` or `private` and defaults to `public`.
+            # @param [Array[channel.ChannelType]] type The visibility of the Channels to read.
+            #   Can be: `public` or `private` and defaults to `public`.
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit. Default is no limit.
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -108,8 +108,8 @@ module Twilio
             ##
             # Retrieve a single page of ChannelInstance records from the API.
             # Request is executed immediately.
-            # @param [channel.ChannelType] type The visibility of the Channels to read. Can
-            #   be: `public` or `private` and defaults to `public`.
+            # @param [Array[channel.ChannelType]] type The visibility of the Channels to read.
+            #   Can be: `public` or `private` and defaults to `public`.
             # @param [String] page_token PageToken provided by the API
             # @param [Integer] page_number Page Number, this value is simply for client state
             # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/chat/v1/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel/invite.rb
@@ -59,7 +59,7 @@ module Twilio
               # Lists InviteInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/api/chat/rest/v1/user]'s `identity` value of
               #   the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/api/chat/guides/create-tokens] for more
@@ -79,7 +79,7 @@ module Twilio
               # Streams InviteInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/api/chat/rest/v1/user]'s `identity` value of
               #   the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/api/chat/guides/create-tokens] for more
@@ -116,7 +116,7 @@ module Twilio
               ##
               # Retrieve a single page of InviteInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/api/chat/rest/v1/user]'s `identity` value of
               #   the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/api/chat/guides/create-tokens] for more

--- a/lib/twilio-ruby/rest/chat/v1/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/channel/member.rb
@@ -59,7 +59,7 @@ module Twilio
               # Lists MemberInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/api/chat/rest/v1/user]'s `identity` value of
               #   the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/api/chat/guides/create-tokens] for more
@@ -79,7 +79,7 @@ module Twilio
               # Streams MemberInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/api/chat/rest/v1/user]'s `identity` value of
               #   the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/api/chat/guides/create-tokens] for more
@@ -116,7 +116,7 @@ module Twilio
               ##
               # Retrieve a single page of MemberInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/api/chat/rest/v1/user]'s `identity` value of
               #   the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/api/chat/guides/create-tokens] for more

--- a/lib/twilio-ruby/rest/chat/v1/service/role.rb
+++ b/lib/twilio-ruby/rest/chat/v1/service/role.rb
@@ -34,10 +34,10 @@ module Twilio
             # @param [role.RoleType] type The type of role. Can be: `channel` for
             #   {Channel}[https://www.twilio.com/docs/chat/api/channels] roles or `deployment`
             #   for {Service}[https://www.twilio.com/docs/chat/api/services] roles.
-            # @param [String] permission A permission that you grant to the new role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
-            #   repeat this parameter for each permission value. The values for this parameter
-            #   depend on the role's `type` and are described in the documentation.
+            # @param [Array[String]] permission A permission that you grant to the new role.
+            #   Only one permission can be granted per parameter. To assign more than one
+            #   permission, repeat this parameter for each permission value. The values for this
+            #   parameter depend on the role's `type` and are described in the documentation.
             # @return [RoleInstance] Created RoleInstance
             def create(friendly_name: nil, type: nil, permission: nil)
               data = Twilio::Values.of({
@@ -203,8 +203,8 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission A permission that you grant to the role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
+            # @param [Array[String]] permission A permission that you grant to the role. Only
+            #   one permission can be granted per parameter. To assign more than one permission,
             #   repeat this parameter for each permission value. The values for this parameter
             #   depend on the role's `type` and are described in the documentation.
             # @return [RoleInstance] Updated RoleInstance
@@ -305,7 +305,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array of the permissions the role has been granted
+            # @return [Array[String]] An array of the permissions the role has been granted
             def permissions
               @properties['permissions']
             end
@@ -344,8 +344,8 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission A permission that you grant to the role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
+            # @param [Array[String]] permission A permission that you grant to the role. Only
+            #   one permission can be granted per parameter. To assign more than one permission,
             #   repeat this parameter for each permission value. The values for this parameter
             #   depend on the role's `type` and are described in the documentation.
             # @return [RoleInstance] Updated RoleInstance

--- a/lib/twilio-ruby/rest/chat/v2/service.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service.rb
@@ -260,8 +260,8 @@ module Twilio
           #   `pre_webhook_url` and `post_webhook_url` webhooks.  Can be: `POST` or `GET` and
           #   the default is `POST`. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
-          # @param [String] webhook_filters The list of webhook events that are enabled for
-          #   this Service instance. See {Webhook
+          # @param [Array[String]] webhook_filters The list of webhook events that are
+          #   enabled for this Service instance. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
           # @param [String] limits_channel_members The maximum number of Members that can be
           #   added to Channels within this Service. Can be up to 1,000.
@@ -557,7 +557,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The list of webhook events that are enabled for this Service instance
+          # @return [Array[String]] The list of webhook events that are enabled for this Service instance
           def webhook_filters
             @properties['webhook_filters']
           end
@@ -684,8 +684,8 @@ module Twilio
           #   `pre_webhook_url` and `post_webhook_url` webhooks.  Can be: `POST` or `GET` and
           #   the default is `POST`. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
-          # @param [String] webhook_filters The list of webhook events that are enabled for
-          #   this Service instance. See {Webhook
+          # @param [Array[String]] webhook_filters The list of webhook events that are
+          #   enabled for this Service instance. See {Webhook
           #   Events}[https://www.twilio.com/docs/chat/webhook-events] for more details.
           # @param [String] limits_channel_members The maximum number of Members that can be
           #   added to Channels within this Service. Can be up to 1,000.

--- a/lib/twilio-ruby/rest/chat/v2/service/binding.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/binding.rb
@@ -31,12 +31,12 @@ module Twilio
             # Lists BindingInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [binding.BindingType] binding_type The push technology used by the
+            # @param [Array[binding.BindingType]] binding_type The push technology used by the
             #   Binding resources to read.  Can be: `apn`, `gcm`, or `fcm`.  See {push
             #   notification
             #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
             #   for more info.
-            # @param [String] identity The
+            # @param [Array[String]] identity The
             #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
             #   of the resources to read. See {access
             #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -60,12 +60,12 @@ module Twilio
             # Streams BindingInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [binding.BindingType] binding_type The push technology used by the
+            # @param [Array[binding.BindingType]] binding_type The push technology used by the
             #   Binding resources to read.  Can be: `apn`, `gcm`, or `fcm`.  See {push
             #   notification
             #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
             #   for more info.
-            # @param [String] identity The
+            # @param [Array[String]] identity The
             #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
             #   of the resources to read. See {access
             #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -101,12 +101,12 @@ module Twilio
             ##
             # Retrieve a single page of BindingInstance records from the API.
             # Request is executed immediately.
-            # @param [binding.BindingType] binding_type The push technology used by the
+            # @param [Array[binding.BindingType]] binding_type The push technology used by the
             #   Binding resources to read.  Can be: `apn`, `gcm`, or `fcm`.  See {push
             #   notification
             #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
             #   for more info.
-            # @param [String] identity The
+            # @param [Array[String]] identity The
             #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
             #   of the resources to read. See {access
             #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -325,7 +325,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The Programmable Chat message types the binding is subscribed to
+            # @return [Array[String]] The Programmable Chat message types the binding is subscribed to
             def message_types
               @properties['message_types']
             end

--- a/lib/twilio-ruby/rest/chat/v2/service/channel.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel.rb
@@ -75,8 +75,8 @@ module Twilio
             # Lists ChannelInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [channel.ChannelType] type The visibility of the Channels to read. Can
-            #   be: `public` or `private` and defaults to `public`.
+            # @param [Array[channel.ChannelType]] type The visibility of the Channels to read.
+            #   Can be: `public` or `private` and defaults to `public`.
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit.  Default is no limit
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -92,8 +92,8 @@ module Twilio
             # Streams ChannelInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [channel.ChannelType] type The visibility of the Channels to read. Can
-            #   be: `public` or `private` and defaults to `public`.
+            # @param [Array[channel.ChannelType]] type The visibility of the Channels to read.
+            #   Can be: `public` or `private` and defaults to `public`.
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit. Default is no limit.
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -126,8 +126,8 @@ module Twilio
             ##
             # Retrieve a single page of ChannelInstance records from the API.
             # Request is executed immediately.
-            # @param [channel.ChannelType] type The visibility of the Channels to read. Can
-            #   be: `public` or `private` and defaults to `public`.
+            # @param [Array[channel.ChannelType]] type The visibility of the Channels to read.
+            #   Can be: `public` or `private` and defaults to `public`.
             # @param [String] page_token PageToken provided by the API
             # @param [Integer] page_number Page Number, this value is simply for client state
             # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/invite.rb
@@ -58,7 +58,7 @@ module Twilio
               # Lists InviteInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
               #   of the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -77,7 +77,7 @@ module Twilio
               # Streams InviteInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
               #   of the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -113,7 +113,7 @@ module Twilio
               ##
               # Retrieve a single page of InviteInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
               #   of the resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/member.rb
@@ -91,7 +91,7 @@ module Twilio
               # Lists MemberInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
               #   of the Member resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -110,7 +110,7 @@ module Twilio
               # Streams MemberInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
               #   of the Member resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.
@@ -146,7 +146,7 @@ module Twilio
               ##
               # Retrieve a single page of MemberInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The
+              # @param [Array[String]] identity The
               #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
               #   of the Member resources to read. See {access
               #   tokens}[https://www.twilio.com/docs/chat/create-tokens] for more details.

--- a/lib/twilio-ruby/rest/chat/v2/service/channel/webhook.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/channel/webhook.rb
@@ -119,15 +119,16 @@ module Twilio
               #   `configuration.method`.
               # @param [webhook.Method] configuration_method The HTTP method used to call
               #   `configuration.url`. Can be: `GET` or `POST` and the default is `POST`.
-              # @param [String] configuration_filters The events that cause us to call the
-              #   Channel Webhook. Used when `type` is `webhook`. This parameter takes only one
-              #   event. To specify more than one event, repeat this parameter for each event. For
-              #   the list of possible events, see {Webhook Event
+              # @param [Array[String]] configuration_filters The events that cause us to call
+              #   the Channel Webhook. Used when `type` is `webhook`. This parameter takes only
+              #   one event. To specify more than one event, repeat this parameter for each event.
+              #   For the list of possible events, see {Webhook Event
               #   Triggers}[https://www.twilio.com/docs/chat/webhook-events#webhook-event-trigger].
-              # @param [String] configuration_triggers A string that will cause us to call the
-              #   webhook when it is present in a message body. This parameter takes only one
-              #   trigger string. To specify more than one, repeat this parameter for each trigger
-              #   string up to a total of 5 trigger strings. Used only when `type` = `trigger`.
+              # @param [Array[String]] configuration_triggers A string that will cause us to
+              #   call the webhook when it is present in a message body. This parameter takes only
+              #   one trigger string. To specify more than one, repeat this parameter for each
+              #   trigger string up to a total of 5 trigger strings. Used only when `type` =
+              #   `trigger`.
               # @param [String] configuration_flow_sid The SID of the Studio
               #   {Flow}[https://www.twilio.com/docs/studio/rest-api/flow] to call when an event
               #   in `configuration.filters` occurs. Used only when `type` is `studio`.
@@ -239,15 +240,16 @@ module Twilio
               #   `configuration.method`.
               # @param [webhook.Method] configuration_method The HTTP method used to call
               #   `configuration.url`. Can be: `GET` or `POST` and the default is `POST`.
-              # @param [String] configuration_filters The events that cause us to call the
-              #   Channel Webhook. Used when `type` is `webhook`. This parameter takes only one
-              #   event. To specify more than one event, repeat this parameter for each event. For
-              #   the list of possible events, see {Webhook Event
+              # @param [Array[String]] configuration_filters The events that cause us to call
+              #   the Channel Webhook. Used when `type` is `webhook`. This parameter takes only
+              #   one event. To specify more than one event, repeat this parameter for each event.
+              #   For the list of possible events, see {Webhook Event
               #   Triggers}[https://www.twilio.com/docs/chat/webhook-events#webhook-event-trigger].
-              # @param [String] configuration_triggers A string that will cause us to call the
-              #   webhook when it is present in a message body. This parameter takes only one
-              #   trigger string. To specify more than one, repeat this parameter for each trigger
-              #   string up to a total of 5 trigger strings. Used only when `type` = `trigger`.
+              # @param [Array[String]] configuration_triggers A string that will cause us to
+              #   call the webhook when it is present in a message body. This parameter takes only
+              #   one trigger string. To specify more than one, repeat this parameter for each
+              #   trigger string up to a total of 5 trigger strings. Used only when `type` =
+              #   `trigger`.
               # @param [String] configuration_flow_sid The SID of the Studio
               #   {Flow}[https://www.twilio.com/docs/studio/rest-api/flow] to call when an event
               #   in `configuration.filters` occurs. Used only when `type` = `studio`.
@@ -419,15 +421,16 @@ module Twilio
               #   `configuration.method`.
               # @param [webhook.Method] configuration_method The HTTP method used to call
               #   `configuration.url`. Can be: `GET` or `POST` and the default is `POST`.
-              # @param [String] configuration_filters The events that cause us to call the
-              #   Channel Webhook. Used when `type` is `webhook`. This parameter takes only one
-              #   event. To specify more than one event, repeat this parameter for each event. For
-              #   the list of possible events, see {Webhook Event
+              # @param [Array[String]] configuration_filters The events that cause us to call
+              #   the Channel Webhook. Used when `type` is `webhook`. This parameter takes only
+              #   one event. To specify more than one event, repeat this parameter for each event.
+              #   For the list of possible events, see {Webhook Event
               #   Triggers}[https://www.twilio.com/docs/chat/webhook-events#webhook-event-trigger].
-              # @param [String] configuration_triggers A string that will cause us to call the
-              #   webhook when it is present in a message body. This parameter takes only one
-              #   trigger string. To specify more than one, repeat this parameter for each trigger
-              #   string up to a total of 5 trigger strings. Used only when `type` = `trigger`.
+              # @param [Array[String]] configuration_triggers A string that will cause us to
+              #   call the webhook when it is present in a message body. This parameter takes only
+              #   one trigger string. To specify more than one, repeat this parameter for each
+              #   trigger string up to a total of 5 trigger strings. Used only when `type` =
+              #   `trigger`.
               # @param [String] configuration_flow_sid The SID of the Studio
               #   {Flow}[https://www.twilio.com/docs/studio/rest-api/flow] to call when an event
               #   in `configuration.filters` occurs. Used only when `type` = `studio`.

--- a/lib/twilio-ruby/rest/chat/v2/service/role.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/role.rb
@@ -34,10 +34,10 @@ module Twilio
             # @param [role.RoleType] type The type of role. Can be: `channel` for
             #   {Channel}[https://www.twilio.com/docs/chat/channels] roles or `deployment` for
             #   {Service}[https://www.twilio.com/docs/chat/rest/service-resource] roles.
-            # @param [String] permission A permission that you grant to the new role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
-            #   repeat this parameter for each permission value. The values for this parameter
-            #   depend on the role's `type`.
+            # @param [Array[String]] permission A permission that you grant to the new role.
+            #   Only one permission can be granted per parameter. To assign more than one
+            #   permission, repeat this parameter for each permission value. The values for this
+            #   parameter depend on the role's `type`.
             # @return [RoleInstance] Created RoleInstance
             def create(friendly_name: nil, type: nil, permission: nil)
               data = Twilio::Values.of({
@@ -202,8 +202,8 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission A permission that you grant to the role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
+            # @param [Array[String]] permission A permission that you grant to the role. Only
+            #   one permission can be granted per parameter. To assign more than one permission,
             #   repeat this parameter for each permission value. Note that the update action
             #   replaces all previously assigned permissions with those defined in the update
             #   action. To remove a permission, do not include it in the subsequent update
@@ -305,7 +305,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array of the permissions the role has been granted
+            # @return [Array[String]] An array of the permissions the role has been granted
             def permissions
               @properties['permissions']
             end
@@ -344,8 +344,8 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission A permission that you grant to the role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
+            # @param [Array[String]] permission A permission that you grant to the role. Only
+            #   one permission can be granted per parameter. To assign more than one permission,
             #   repeat this parameter for each permission value. Note that the update action
             #   replaces all previously assigned permissions with those defined in the update
             #   action. To remove a permission, do not include it in the subsequent update

--- a/lib/twilio-ruby/rest/chat/v2/service/user/user_binding.rb
+++ b/lib/twilio-ruby/rest/chat/v2/service/user/user_binding.rb
@@ -37,9 +37,9 @@ module Twilio
               # Lists UserBindingInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [user_binding.BindingType] binding_type The push technology used by the
-              #   User Binding resources to read. Can be: `apn`, `gcm`, or `fcm`.  See {push
-              #   notification
+              # @param [Array[user_binding.BindingType]] binding_type The push technology used
+              #   by the User Binding resources to read. Can be: `apn`, `gcm`, or `fcm`.  See
+              #   {push notification
               #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
               #   for more info.
               # @param [Integer] limit Upper limit for the number of records to return. stream()
@@ -57,9 +57,9 @@ module Twilio
               # Streams UserBindingInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [user_binding.BindingType] binding_type The push technology used by the
-              #   User Binding resources to read. Can be: `apn`, `gcm`, or `fcm`.  See {push
-              #   notification
+              # @param [Array[user_binding.BindingType]] binding_type The push technology used
+              #   by the User Binding resources to read. Can be: `apn`, `gcm`, or `fcm`.  See
+              #   {push notification
               #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
               #   for more info.
               # @param [Integer] limit Upper limit for the number of records to return. stream()
@@ -94,9 +94,9 @@ module Twilio
               ##
               # Retrieve a single page of UserBindingInstance records from the API.
               # Request is executed immediately.
-              # @param [user_binding.BindingType] binding_type The push technology used by the
-              #   User Binding resources to read. Can be: `apn`, `gcm`, or `fcm`.  See {push
-              #   notification
+              # @param [Array[user_binding.BindingType]] binding_type The push technology used
+              #   by the User Binding resources to read. Can be: `apn`, `gcm`, or `fcm`.  See
+              #   {push notification
               #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
               #   for more info.
               # @param [String] page_token PageToken provided by the API
@@ -345,7 +345,7 @@ module Twilio
               end
 
               ##
-              # @return [String] The Programmable Chat message types the binding is subscribed to
+              # @return [Array[String]] The Programmable Chat message types the binding is subscribed to
               def message_types
                 @properties['message_types']
               end

--- a/lib/twilio-ruby/rest/conversations/v1/configuration/webhook.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/configuration/webhook.rb
@@ -85,10 +85,10 @@ module Twilio
             # Update the WebhookInstance
             # @param [String] method The HTTP method to be used when sending a webhook
             #   request.
-            # @param [String] filters The list of webhook event triggers that are enabled for
-            #   this Service: `onMessageAdded`, `onMessageUpdated`, `onMessageRemoved`,
-            #   `onConversationUpdated`, `onConversationRemoved`, `onParticipantAdded`,
-            #   `onParticipantUpdated`, `onParticipantRemoved`
+            # @param [Array[String]] filters The list of webhook event triggers that are
+            #   enabled for this Service: `onMessageAdded`, `onMessageUpdated`,
+            #   `onMessageRemoved`, `onConversationUpdated`, `onConversationRemoved`,
+            #   `onParticipantAdded`, `onParticipantUpdated`, `onParticipantRemoved`
             # @param [String] pre_webhook_url The absolute url the pre-event webhook request
             #   should be sent to.
             # @param [String] post_webhook_url The absolute url the post-event webhook request
@@ -173,7 +173,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of webhook event triggers that are enabled for this Service.
+            # @return [Array[String]] The list of webhook event triggers that are enabled for this Service.
             def filters
               @properties['filters']
             end
@@ -213,10 +213,10 @@ module Twilio
             # Update the WebhookInstance
             # @param [String] method The HTTP method to be used when sending a webhook
             #   request.
-            # @param [String] filters The list of webhook event triggers that are enabled for
-            #   this Service: `onMessageAdded`, `onMessageUpdated`, `onMessageRemoved`,
-            #   `onConversationUpdated`, `onConversationRemoved`, `onParticipantAdded`,
-            #   `onParticipantUpdated`, `onParticipantRemoved`
+            # @param [Array[String]] filters The list of webhook event triggers that are
+            #   enabled for this Service: `onMessageAdded`, `onMessageUpdated`,
+            #   `onMessageRemoved`, `onConversationUpdated`, `onConversationRemoved`,
+            #   `onParticipantAdded`, `onParticipantUpdated`, `onParticipantRemoved`
             # @param [String] pre_webhook_url The absolute url the pre-event webhook request
             #   should be sent to.
             # @param [String] post_webhook_url The absolute url the post-event webhook request

--- a/lib/twilio-ruby/rest/conversations/v1/conversation/message.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation/message.rb
@@ -378,7 +378,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] An array of objects that describe the Message's media if attached, otherwise, null.
+            # @return [Array[Hash]] An array of objects that describe the Message's media if attached, otherwise, null.
             def media
               @properties['media']
             end

--- a/lib/twilio-ruby/rest/conversations/v1/conversation/webhook.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/conversation/webhook.rb
@@ -115,10 +115,10 @@ module Twilio
             #   sent to.
             # @param [webhook.Method] configuration_method The HTTP method to be used when
             #   sending a webhook request.
-            # @param [String] configuration_filters The list of events, firing webhook event
-            #   for this Conversation.
-            # @param [String] configuration_triggers The list of keywords, firing webhook
+            # @param [Array[String]] configuration_filters The list of events, firing webhook
             #   event for this Conversation.
+            # @param [Array[String]] configuration_triggers The list of keywords, firing
+            #   webhook event for this Conversation.
             # @param [String] configuration_flow_sid The studio flow SID, where the webhook
             #   should be sent to.
             # @param [String] configuration_replay_after The message index for which and it's
@@ -214,10 +214,10 @@ module Twilio
             #   sent to.
             # @param [webhook.Method] configuration_method The HTTP method to be used when
             #   sending a webhook request.
-            # @param [String] configuration_filters The list of events, firing webhook event
-            #   for this Conversation.
-            # @param [String] configuration_triggers The list of keywords, firing webhook
+            # @param [Array[String]] configuration_filters The list of events, firing webhook
             #   event for this Conversation.
+            # @param [Array[String]] configuration_triggers The list of keywords, firing
+            #   webhook event for this Conversation.
             # @param [String] configuration_flow_sid The studio flow SID, where the webhook
             #   should be sent to.
             # @return [WebhookInstance] Updated WebhookInstance
@@ -365,10 +365,10 @@ module Twilio
             #   sent to.
             # @param [webhook.Method] configuration_method The HTTP method to be used when
             #   sending a webhook request.
-            # @param [String] configuration_filters The list of events, firing webhook event
-            #   for this Conversation.
-            # @param [String] configuration_triggers The list of keywords, firing webhook
+            # @param [Array[String]] configuration_filters The list of events, firing webhook
             #   event for this Conversation.
+            # @param [Array[String]] configuration_triggers The list of keywords, firing
+            #   webhook event for this Conversation.
             # @param [String] configuration_flow_sid The studio flow SID, where the webhook
             #   should be sent to.
             # @return [WebhookInstance] Updated WebhookInstance

--- a/lib/twilio-ruby/rest/conversations/v1/role.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/role.rb
@@ -31,10 +31,10 @@ module Twilio
           #   {Conversation}[https://www.twilio.com/docs/conversations/api/conversation-resource]
           #   roles or `service` for {Conversation
           #   Service}[https://www.twilio.com/docs/conversations/api/service-resource] roles.
-          # @param [String] permission A permission that you grant to the new role. Only one
-          #   permission can be granted per parameter. To assign more than one permission,
-          #   repeat this parameter for each permission value. The values for this parameter
-          #   depend on the role's `type`.
+          # @param [Array[String]] permission A permission that you grant to the new role.
+          #   Only one permission can be granted per parameter. To assign more than one
+          #   permission, repeat this parameter for each permission value. The values for this
+          #   parameter depend on the role's `type`.
           # @return [RoleInstance] Created RoleInstance
           def create(friendly_name: nil, type: nil, permission: nil)
             data = Twilio::Values.of({
@@ -180,8 +180,8 @@ module Twilio
 
           ##
           # Update the RoleInstance
-          # @param [String] permission A permission that you grant to the role. Only one
-          #   permission can be granted per parameter. To assign more than one permission,
+          # @param [Array[String]] permission A permission that you grant to the role. Only
+          #   one permission can be granted per parameter. To assign more than one permission,
           #   repeat this parameter for each permission value. Note that the update action
           #   replaces all previously assigned permissions with those defined in the update
           #   action. To remove a permission, do not include it in the subsequent update
@@ -296,7 +296,7 @@ module Twilio
           end
 
           ##
-          # @return [String] An array of the permissions the role has been granted
+          # @return [Array[String]] An array of the permissions the role has been granted
           def permissions
             @properties['permissions']
           end
@@ -321,8 +321,8 @@ module Twilio
 
           ##
           # Update the RoleInstance
-          # @param [String] permission A permission that you grant to the role. Only one
-          #   permission can be granted per parameter. To assign more than one permission,
+          # @param [Array[String]] permission A permission that you grant to the role. Only
+          #   one permission can be granted per parameter. To assign more than one permission,
           #   repeat this parameter for each permission value. Note that the update action
           #   replaces all previously assigned permissions with those defined in the update
           #   action. To remove a permission, do not include it in the subsequent update

--- a/lib/twilio-ruby/rest/conversations/v1/service/binding.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/service/binding.rb
@@ -31,12 +31,12 @@ module Twilio
             # Lists BindingInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [binding.BindingType] binding_type The push technology used by the
+            # @param [Array[binding.BindingType]] binding_type The push technology used by the
             #   Binding resources to read.  Can be: `apn`, `gcm`, or `fcm`.  See {push
             #   notification
             #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
             #   for more info.
-            # @param [String] identity The identity of a {Conversation
+            # @param [Array[String]] identity The identity of a {Conversation
             #   User}[https://www.twilio.com/docs/conversations/api/user-resource] this binding
             #   belongs to. See {access
             #   tokens}[https://www.twilio.com/docs/conversations/create-tokens] for more
@@ -61,12 +61,12 @@ module Twilio
             # Streams BindingInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [binding.BindingType] binding_type The push technology used by the
+            # @param [Array[binding.BindingType]] binding_type The push technology used by the
             #   Binding resources to read.  Can be: `apn`, `gcm`, or `fcm`.  See {push
             #   notification
             #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
             #   for more info.
-            # @param [String] identity The identity of a {Conversation
+            # @param [Array[String]] identity The identity of a {Conversation
             #   User}[https://www.twilio.com/docs/conversations/api/user-resource] this binding
             #   belongs to. See {access
             #   tokens}[https://www.twilio.com/docs/conversations/create-tokens] for more
@@ -103,12 +103,12 @@ module Twilio
             ##
             # Retrieve a single page of BindingInstance records from the API.
             # Request is executed immediately.
-            # @param [binding.BindingType] binding_type The push technology used by the
+            # @param [Array[binding.BindingType]] binding_type The push technology used by the
             #   Binding resources to read.  Can be: `apn`, `gcm`, or `fcm`.  See {push
             #   notification
             #   configuration}[https://www.twilio.com/docs/chat/push-notification-configuration]
             #   for more info.
-            # @param [String] identity The identity of a {Conversation
+            # @param [Array[String]] identity The identity of a {Conversation
             #   User}[https://www.twilio.com/docs/conversations/api/user-resource] this binding
             #   belongs to. See {access
             #   tokens}[https://www.twilio.com/docs/conversations/create-tokens] for more
@@ -334,7 +334,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The Conversation message types the binding is subscribed to.
+            # @return [Array[String]] The Conversation message types the binding is subscribed to.
             def message_types
               @properties['message_types']
             end

--- a/lib/twilio-ruby/rest/conversations/v1/service/conversation/message.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/service/conversation/message.rb
@@ -423,7 +423,7 @@ module Twilio
               end
 
               ##
-              # @return [Hash] An array of objects that describe the Message's media if attached, otherwise, null.
+              # @return [Array[Hash]] An array of objects that describe the Message's media if attached, otherwise, null.
               def media
                 @properties['media']
               end

--- a/lib/twilio-ruby/rest/conversations/v1/service/conversation/webhook.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/service/conversation/webhook.rb
@@ -39,10 +39,10 @@ module Twilio
               #   sent to.
               # @param [webhook.Method] configuration_method The HTTP method to be used when
               #   sending a webhook request.
-              # @param [String] configuration_filters The list of events, firing webhook event
-              #   for this Conversation.
-              # @param [String] configuration_triggers The list of keywords, firing webhook
+              # @param [Array[String]] configuration_filters The list of events, firing webhook
               #   event for this Conversation.
+              # @param [Array[String]] configuration_triggers The list of keywords, firing
+              #   webhook event for this Conversation.
               # @param [String] configuration_flow_sid The studio flow SID, where the webhook
               #   should be sent to.
               # @param [String] configuration_replay_after The message index for which and it's
@@ -217,10 +217,10 @@ module Twilio
               #   sent to.
               # @param [webhook.Method] configuration_method The HTTP method to be used when
               #   sending a webhook request.
-              # @param [String] configuration_filters The list of events, firing webhook event
-              #   for this Conversation.
-              # @param [String] configuration_triggers The list of keywords, firing webhook
+              # @param [Array[String]] configuration_filters The list of events, firing webhook
               #   event for this Conversation.
+              # @param [Array[String]] configuration_triggers The list of keywords, firing
+              #   webhook event for this Conversation.
               # @param [String] configuration_flow_sid The studio flow SID, where the webhook
               #   should be sent to.
               # @return [WebhookInstance] Updated WebhookInstance
@@ -396,10 +396,10 @@ module Twilio
               #   sent to.
               # @param [webhook.Method] configuration_method The HTTP method to be used when
               #   sending a webhook request.
-              # @param [String] configuration_filters The list of events, firing webhook event
-              #   for this Conversation.
-              # @param [String] configuration_triggers The list of keywords, firing webhook
+              # @param [Array[String]] configuration_filters The list of events, firing webhook
               #   event for this Conversation.
+              # @param [Array[String]] configuration_triggers The list of keywords, firing
+              #   webhook event for this Conversation.
               # @param [String] configuration_flow_sid The studio flow SID, where the webhook
               #   should be sent to.
               # @return [WebhookInstance] Updated WebhookInstance

--- a/lib/twilio-ruby/rest/conversations/v1/service/role.rb
+++ b/lib/twilio-ruby/rest/conversations/v1/service/role.rb
@@ -35,10 +35,10 @@ module Twilio
             #   {Conversation}[https://www.twilio.com/docs/conversations/api/conversation-resource]
             #   roles or `service` for {Conversation
             #   Service}[https://www.twilio.com/docs/conversations/api/service-resource] roles.
-            # @param [String] permission A permission that you grant to the new role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
-            #   repeat this parameter for each permission value. The values for this parameter
-            #   depend on the role's `type`.
+            # @param [Array[String]] permission A permission that you grant to the new role.
+            #   Only one permission can be granted per parameter. To assign more than one
+            #   permission, repeat this parameter for each permission value. The values for this
+            #   parameter depend on the role's `type`.
             # @return [RoleInstance] Created RoleInstance
             def create(friendly_name: nil, type: nil, permission: nil)
               data = Twilio::Values.of({
@@ -187,8 +187,8 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission A permission that you grant to the role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
+            # @param [Array[String]] permission A permission that you grant to the role. Only
+            #   one permission can be granted per parameter. To assign more than one permission,
             #   repeat this parameter for each permission value. Note that the update action
             #   replaces all previously assigned permissions with those defined in the update
             #   action. To remove a permission, do not include it in the subsequent update
@@ -316,7 +316,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array of the permissions the role has been granted
+            # @return [Array[String]] An array of the permissions the role has been granted
             def permissions
               @properties['permissions']
             end
@@ -341,8 +341,8 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission A permission that you grant to the role. Only one
-            #   permission can be granted per parameter. To assign more than one permission,
+            # @param [Array[String]] permission A permission that you grant to the role. Only
+            #   one permission can be granted per parameter. To assign more than one permission,
             #   repeat this parameter for each permission value. Note that the update action
             #   replaces all previously assigned permissions with those defined in the update
             #   action. To remove a permission, do not include it in the subsequent update

--- a/lib/twilio-ruby/rest/events/v1/subscription.rb
+++ b/lib/twilio-ruby/rest/events/v1/subscription.rb
@@ -118,8 +118,8 @@ module Twilio
           # @param [String] sink_sid The SID of the sink that events selected by this
           #   subscription should be sent to. Sink must be active for the subscription to be
           #   created.
-          # @param [Hash] types Contains a dictionary of URL links to nested resources of
-          #   this Subscription.
+          # @param [Array[Hash]] types Contains a dictionary of URL links to nested
+          #   resources of this Subscription.
           # @return [SubscriptionInstance] Created SubscriptionInstance
           def create(description: nil, sink_sid: nil, types: nil)
             data = Twilio::Values.of({

--- a/lib/twilio-ruby/rest/flex_api/v1/configuration.rb
+++ b/lib/twilio-ruby/rest/flex_api/v1/configuration.rb
@@ -232,13 +232,13 @@ module Twilio
           end
 
           ##
-          # @return [Hash] The list of TaskRouter TaskQueues
+          # @return [Array[Hash]] The list of TaskRouter TaskQueues
           def taskrouter_taskqueues
             @properties['taskrouter_taskqueues']
           end
 
           ##
-          # @return [Hash] The Skill description for TaskRouter workers
+          # @return [Array[Hash]] The Skill description for TaskRouter workers
           def taskrouter_skills
             @properties['taskrouter_skills']
           end
@@ -376,7 +376,7 @@ module Twilio
           end
 
           ##
-          # @return [Hash] A list of objects that contain the configurations for the Integrations supported in this configuration
+          # @return [Array[Hash]] A list of objects that contain the configurations for the Integrations supported in this configuration
           def integrations
             @properties['integrations']
           end
@@ -388,7 +388,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The list of serverless service SIDs
+          # @return [Array[String]] The list of serverless service SIDs
           def serverless_service_sids
             @properties['serverless_service_sids']
           end

--- a/lib/twilio-ruby/rest/insights/v1/call/summary.rb
+++ b/lib/twilio-ruby/rest/insights/v1/call/summary.rb
@@ -250,7 +250,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The tags
+            # @return [Array[String]] The tags
             def tags
               @properties['tags']
             end

--- a/lib/twilio-ruby/rest/insights/v1/room.rb
+++ b/lib/twilio-ruby/rest/insights/v1/room.rb
@@ -29,8 +29,8 @@ module Twilio
           # Lists RoomInstance records from the API as a list.
           # Unlike stream(), this operation is eager and will load `limit` records into
           # memory before returning.
-          # @param [room.RoomType] room_type The room_type
-          # @param [room.Codec] codec The codec
+          # @param [Array[room.RoomType]] room_type The room_type
+          # @param [Array[room.Codec]] codec The codec
           # @param [String] room_name The room_name
           # @param [Time] created_after The created_after
           # @param [Time] created_before The created_before
@@ -57,8 +57,8 @@ module Twilio
           # Streams RoomInstance records from the API as an Enumerable.
           # This operation lazily loads records as efficiently as possible until the limit
           # is reached.
-          # @param [room.RoomType] room_type The room_type
-          # @param [room.Codec] codec The codec
+          # @param [Array[room.RoomType]] room_type The room_type
+          # @param [Array[room.Codec]] codec The codec
           # @param [String] room_name The room_name
           # @param [Time] created_after The created_after
           # @param [Time] created_before The created_before
@@ -101,8 +101,8 @@ module Twilio
           ##
           # Retrieve a single page of RoomInstance records from the API.
           # Request is executed immediately.
-          # @param [room.RoomType] room_type The room_type
-          # @param [room.Codec] codec The codec
+          # @param [Array[room.RoomType]] room_type The room_type
+          # @param [Array[room.Codec]] codec The codec
           # @param [String] room_name The room_name
           # @param [Time] created_after The created_after
           # @param [Time] created_before The created_before
@@ -394,7 +394,7 @@ module Twilio
           end
 
           ##
-          # @return [room.Codec] The codecs
+          # @return [Array[room.Codec]] The codecs
           def codecs
             @properties['codecs']
           end

--- a/lib/twilio-ruby/rest/insights/v1/room/participant.rb
+++ b/lib/twilio-ruby/rest/insights/v1/room/participant.rb
@@ -297,7 +297,7 @@ module Twilio
             end
 
             ##
-            # @return [participant.Codec] The codecs
+            # @return [Array[participant.Codec]] The codecs
             def codecs
               @properties['codecs']
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service.rb
@@ -216,7 +216,7 @@ module Twilio
           # @param [String] pre_webhook_url The pre_webhook_url
           # @param [String] post_webhook_url The post_webhook_url
           # @param [String] webhook_method The webhook_method
-          # @param [String] webhook_filters The webhook_filters
+          # @param [Array[String]] webhook_filters The webhook_filters
           # @param [String] webhooks_on_message_send_url The webhooks.on_message_send.url
           # @param [String] webhooks_on_message_send_method The
           #   webhooks.on_message_send.method
@@ -562,7 +562,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The webhook_filters
+          # @return [Array[String]] The webhook_filters
           def webhook_filters
             @properties['webhook_filters']
           end
@@ -629,7 +629,7 @@ module Twilio
           # @param [String] pre_webhook_url The pre_webhook_url
           # @param [String] post_webhook_url The post_webhook_url
           # @param [String] webhook_method The webhook_method
-          # @param [String] webhook_filters The webhook_filters
+          # @param [Array[String]] webhook_filters The webhook_filters
           # @param [String] webhooks_on_message_send_url The webhooks.on_message_send.url
           # @param [String] webhooks_on_message_send_method The
           #   webhooks.on_message_send.method

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel.rb
@@ -49,7 +49,7 @@ module Twilio
             # Lists ChannelInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [channel.ChannelType] type The type
+            # @param [Array[channel.ChannelType]] type The type
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit.  Default is no limit
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -65,7 +65,7 @@ module Twilio
             # Streams ChannelInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [channel.ChannelType] type The type
+            # @param [Array[channel.ChannelType]] type The type
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit. Default is no limit.
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -98,7 +98,7 @@ module Twilio
             ##
             # Retrieve a single page of ChannelInstance records from the API.
             # Request is executed immediately.
-            # @param [channel.ChannelType] type The type
+            # @param [Array[channel.ChannelType]] type The type
             # @param [String] page_token PageToken provided by the API
             # @param [Integer] page_number Page Number, this value is simply for client state
             # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/invite.rb
@@ -49,7 +49,7 @@ module Twilio
               # Lists InviteInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit.  Default is no limit
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -65,7 +65,7 @@ module Twilio
               # Streams InviteInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit. Default is no limit.
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -98,7 +98,7 @@ module Twilio
               ##
               # Retrieve a single page of InviteInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [String] page_token PageToken provided by the API
               # @param [Integer] page_number Page Number, this value is simply for client state
               # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/channel/member.rb
@@ -49,7 +49,7 @@ module Twilio
               # Lists MemberInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit.  Default is no limit
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -65,7 +65,7 @@ module Twilio
               # Streams MemberInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit. Default is no limit.
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -98,7 +98,7 @@ module Twilio
               ##
               # Retrieve a single page of MemberInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [String] page_token PageToken provided by the API
               # @param [Integer] page_number Page Number, this value is simply for client state
               # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/ip_messaging/v1/service/role.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1/service/role.rb
@@ -29,7 +29,7 @@ module Twilio
             # Create the RoleInstance
             # @param [String] friendly_name The friendly_name
             # @param [role.RoleType] type The type
-            # @param [String] permission The permission
+            # @param [Array[String]] permission The permission
             # @return [RoleInstance] Created RoleInstance
             def create(friendly_name: nil, type: nil, permission: nil)
               data = Twilio::Values.of({
@@ -192,7 +192,7 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission The permission
+            # @param [Array[String]] permission The permission
             # @return [RoleInstance] Updated RoleInstance
             def update(permission: nil)
               data = Twilio::Values.of({'Permission' => Twilio.serialize_list(permission) { |e| e }, })
@@ -288,7 +288,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The permissions
+            # @return [Array[String]] The permissions
             def permissions
               @properties['permissions']
             end
@@ -327,7 +327,7 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission The permission
+            # @param [Array[String]] permission The permission
             # @return [RoleInstance] Updated RoleInstance
             def update(permission: nil)
               context.update(permission: permission, )

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service.rb
@@ -227,7 +227,7 @@ module Twilio
           # @param [String] pre_webhook_url The pre_webhook_url
           # @param [String] post_webhook_url The post_webhook_url
           # @param [String] webhook_method The webhook_method
-          # @param [String] webhook_filters The webhook_filters
+          # @param [Array[String]] webhook_filters The webhook_filters
           # @param [String] limits_channel_members The limits.channel_members
           # @param [String] limits_user_channels The limits.user_channels
           # @param [String] media_compatibility_message The media.compatibility_message
@@ -512,7 +512,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The webhook_filters
+          # @return [Array[String]] The webhook_filters
           def webhook_filters
             @properties['webhook_filters']
           end
@@ -607,7 +607,7 @@ module Twilio
           # @param [String] pre_webhook_url The pre_webhook_url
           # @param [String] post_webhook_url The post_webhook_url
           # @param [String] webhook_method The webhook_method
-          # @param [String] webhook_filters The webhook_filters
+          # @param [Array[String]] webhook_filters The webhook_filters
           # @param [String] limits_channel_members The limits.channel_members
           # @param [String] limits_user_channels The limits.user_channels
           # @param [String] media_compatibility_message The media.compatibility_message

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/binding.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/binding.rb
@@ -29,8 +29,8 @@ module Twilio
             # Lists BindingInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [binding.BindingType] binding_type The binding_type
-            # @param [String] identity The identity
+            # @param [Array[binding.BindingType]] binding_type The binding_type
+            # @param [Array[String]] identity The identity
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit.  Default is no limit
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -51,8 +51,8 @@ module Twilio
             # Streams BindingInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [binding.BindingType] binding_type The binding_type
-            # @param [String] identity The identity
+            # @param [Array[binding.BindingType]] binding_type The binding_type
+            # @param [Array[String]] identity The identity
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit. Default is no limit.
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -85,8 +85,8 @@ module Twilio
             ##
             # Retrieve a single page of BindingInstance records from the API.
             # Request is executed immediately.
-            # @param [binding.BindingType] binding_type The binding_type
-            # @param [String] identity The identity
+            # @param [Array[binding.BindingType]] binding_type The binding_type
+            # @param [Array[String]] identity The identity
             # @param [String] page_token PageToken provided by the API
             # @param [Integer] page_number Page Number, this value is simply for client state
             # @param [Integer] page_size Number of records to return, defaults to 50
@@ -298,7 +298,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The message_types
+            # @return [Array[String]] The message_types
             def message_types
               @properties['message_types']
             end

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel.rb
@@ -58,7 +58,7 @@ module Twilio
             # Lists ChannelInstance records from the API as a list.
             # Unlike stream(), this operation is eager and will load `limit` records into
             # memory before returning.
-            # @param [channel.ChannelType] type The type
+            # @param [Array[channel.ChannelType]] type The type
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit.  Default is no limit
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -74,7 +74,7 @@ module Twilio
             # Streams ChannelInstance records from the API as an Enumerable.
             # This operation lazily loads records as efficiently as possible until the limit
             # is reached.
-            # @param [channel.ChannelType] type The type
+            # @param [Array[channel.ChannelType]] type The type
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit. Default is no limit.
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -107,7 +107,7 @@ module Twilio
             ##
             # Retrieve a single page of ChannelInstance records from the API.
             # Request is executed immediately.
-            # @param [channel.ChannelType] type The type
+            # @param [Array[channel.ChannelType]] type The type
             # @param [String] page_token PageToken provided by the API
             # @param [Integer] page_number Page Number, this value is simply for client state
             # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/invite.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/invite.rb
@@ -49,7 +49,7 @@ module Twilio
               # Lists InviteInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit.  Default is no limit
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -65,7 +65,7 @@ module Twilio
               # Streams InviteInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit. Default is no limit.
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -98,7 +98,7 @@ module Twilio
               ##
               # Retrieve a single page of InviteInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [String] page_token PageToken provided by the API
               # @param [Integer] page_number Page Number, this value is simply for client state
               # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/member.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/member.rb
@@ -65,7 +65,7 @@ module Twilio
               # Lists MemberInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit.  Default is no limit
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -81,7 +81,7 @@ module Twilio
               # Streams MemberInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit. Default is no limit.
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -114,7 +114,7 @@ module Twilio
               ##
               # Retrieve a single page of MemberInstance records from the API.
               # Request is executed immediately.
-              # @param [String] identity The identity
+              # @param [Array[String]] identity The identity
               # @param [String] page_token PageToken provided by the API
               # @param [Integer] page_number Page Number, this value is simply for client state
               # @param [Integer] page_size Number of records to return, defaults to 50

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/webhook.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/channel/webhook.rb
@@ -112,8 +112,8 @@ module Twilio
               # @param [webhook.Type] type The type
               # @param [String] configuration_url The configuration.url
               # @param [webhook.Method] configuration_method The configuration.method
-              # @param [String] configuration_filters The configuration.filters
-              # @param [String] configuration_triggers The configuration.triggers
+              # @param [Array[String]] configuration_filters The configuration.filters
+              # @param [Array[String]] configuration_triggers The configuration.triggers
               # @param [String] configuration_flow_sid The configuration.flow_sid
               # @param [String] configuration_retry_count The configuration.retry_count
               # @return [WebhookInstance] Created WebhookInstance
@@ -214,8 +214,8 @@ module Twilio
               # Update the WebhookInstance
               # @param [String] configuration_url The configuration.url
               # @param [webhook.Method] configuration_method The configuration.method
-              # @param [String] configuration_filters The configuration.filters
-              # @param [String] configuration_triggers The configuration.triggers
+              # @param [Array[String]] configuration_filters The configuration.filters
+              # @param [Array[String]] configuration_triggers The configuration.triggers
               # @param [String] configuration_flow_sid The configuration.flow_sid
               # @param [String] configuration_retry_count The configuration.retry_count
               # @return [WebhookInstance] Updated WebhookInstance
@@ -377,8 +377,8 @@ module Twilio
               # Update the WebhookInstance
               # @param [String] configuration_url The configuration.url
               # @param [webhook.Method] configuration_method The configuration.method
-              # @param [String] configuration_filters The configuration.filters
-              # @param [String] configuration_triggers The configuration.triggers
+              # @param [Array[String]] configuration_filters The configuration.filters
+              # @param [Array[String]] configuration_triggers The configuration.triggers
               # @param [String] configuration_flow_sid The configuration.flow_sid
               # @param [String] configuration_retry_count The configuration.retry_count
               # @return [WebhookInstance] Updated WebhookInstance

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/role.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/role.rb
@@ -29,7 +29,7 @@ module Twilio
             # Create the RoleInstance
             # @param [String] friendly_name The friendly_name
             # @param [role.RoleType] type The type
-            # @param [String] permission The permission
+            # @param [Array[String]] permission The permission
             # @return [RoleInstance] Created RoleInstance
             def create(friendly_name: nil, type: nil, permission: nil)
               data = Twilio::Values.of({
@@ -192,7 +192,7 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission The permission
+            # @param [Array[String]] permission The permission
             # @return [RoleInstance] Updated RoleInstance
             def update(permission: nil)
               data = Twilio::Values.of({'Permission' => Twilio.serialize_list(permission) { |e| e }, })
@@ -288,7 +288,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The permissions
+            # @return [Array[String]] The permissions
             def permissions
               @properties['permissions']
             end
@@ -327,7 +327,7 @@ module Twilio
 
             ##
             # Update the RoleInstance
-            # @param [String] permission The permission
+            # @param [Array[String]] permission The permission
             # @return [RoleInstance] Updated RoleInstance
             def update(permission: nil)
               context.update(permission: permission, )

--- a/lib/twilio-ruby/rest/ip_messaging/v2/service/user/user_binding.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2/service/user/user_binding.rb
@@ -31,7 +31,7 @@ module Twilio
               # Lists UserBindingInstance records from the API as a list.
               # Unlike stream(), this operation is eager and will load `limit` records into
               # memory before returning.
-              # @param [user_binding.BindingType] binding_type The binding_type
+              # @param [Array[user_binding.BindingType]] binding_type The binding_type
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit.  Default is no limit
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -47,7 +47,7 @@ module Twilio
               # Streams UserBindingInstance records from the API as an Enumerable.
               # This operation lazily loads records as efficiently as possible until the limit
               # is reached.
-              # @param [user_binding.BindingType] binding_type The binding_type
+              # @param [Array[user_binding.BindingType]] binding_type The binding_type
               # @param [Integer] limit Upper limit for the number of records to return. stream()
               #    guarantees to never return more than limit. Default is no limit.
               # @param [Integer] page_size Number of records to fetch per request, when
@@ -80,7 +80,7 @@ module Twilio
               ##
               # Retrieve a single page of UserBindingInstance records from the API.
               # Request is executed immediately.
-              # @param [user_binding.BindingType] binding_type The binding_type
+              # @param [Array[user_binding.BindingType]] binding_type The binding_type
               # @param [String] page_token PageToken provided by the API
               # @param [Integer] page_number Page Number, this value is simply for client state
               # @param [Integer] page_size Number of records to return, defaults to 50
@@ -315,7 +315,7 @@ module Twilio
               end
 
               ##
-              # @return [String] The message_types
+              # @return [Array[String]] The message_types
               def message_types
                 @properties['message_types']
               end

--- a/lib/twilio-ruby/rest/lookups/v1/phone_number.rb
+++ b/lib/twilio-ruby/rest/lookups/v1/phone_number.rb
@@ -80,16 +80,16 @@ module Twilio
           #   code}[https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2] of the phone number to
           #   fetch. This is used to specify the country when the phone number is provided in
           #   a national format.
-          # @param [String] type The type of information to return. Can be: `carrier` or
-          #   `caller-name`. The default is null.  Carrier information costs $0.005 per phone
-          #   number looked up.  Caller Name information is currently available only in the US
-          #   and costs $0.01 per phone number looked up.  To retrieve both types on
+          # @param [Array[String]] type The type of information to return. Can be: `carrier`
+          #   or `caller-name`. The default is null.  Carrier information costs $0.005 per
+          #   phone number looked up.  Caller Name information is currently available only in
+          #   the US and costs $0.01 per phone number looked up.  To retrieve both types on
           #   information, specify this parameter twice; once with `carrier` and once with
           #   `caller-name` as the value.
-          # @param [String] add_ons The `unique_name` of an Add-on you would like to invoke.
-          #   Can be the `unique_name` of an Add-on that is installed on your account. You can
-          #   specify multiple instances of this parameter to invoke multiple Add-ons. For
-          #   more information about  Add-ons, see the {Add-ons
+          # @param [Array[String]] add_ons The `unique_name` of an Add-on you would like to
+          #   invoke. Can be the `unique_name` of an Add-on that is installed on your account.
+          #   You can specify multiple instances of this parameter to invoke multiple Add-ons.
+          #   For more information about  Add-ons, see the {Add-ons
           #   documentation}[https://www.twilio.com/docs/add-ons].
           # @param [Hash] add_ons_data Data specific to the add-on you would like to invoke.
           #   The content and format of this value depends on the add-on.
@@ -209,16 +209,16 @@ module Twilio
           #   code}[https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2] of the phone number to
           #   fetch. This is used to specify the country when the phone number is provided in
           #   a national format.
-          # @param [String] type The type of information to return. Can be: `carrier` or
-          #   `caller-name`. The default is null.  Carrier information costs $0.005 per phone
-          #   number looked up.  Caller Name information is currently available only in the US
-          #   and costs $0.01 per phone number looked up.  To retrieve both types on
+          # @param [Array[String]] type The type of information to return. Can be: `carrier`
+          #   or `caller-name`. The default is null.  Carrier information costs $0.005 per
+          #   phone number looked up.  Caller Name information is currently available only in
+          #   the US and costs $0.01 per phone number looked up.  To retrieve both types on
           #   information, specify this parameter twice; once with `carrier` and once with
           #   `caller-name` as the value.
-          # @param [String] add_ons The `unique_name` of an Add-on you would like to invoke.
-          #   Can be the `unique_name` of an Add-on that is installed on your account. You can
-          #   specify multiple instances of this parameter to invoke multiple Add-ons. For
-          #   more information about  Add-ons, see the {Add-ons
+          # @param [Array[String]] add_ons The `unique_name` of an Add-on you would like to
+          #   invoke. Can be the `unique_name` of an Add-on that is installed on your account.
+          #   You can specify multiple instances of this parameter to invoke multiple Add-ons.
+          #   For more information about  Add-ons, see the {Add-ons
           #   documentation}[https://www.twilio.com/docs/add-ons].
           # @param [Hash] add_ons_data Data specific to the add-on you would like to invoke.
           #   The content and format of this value depends on the add-on.

--- a/lib/twilio-ruby/rest/messaging/v1/service/alpha_sender.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service/alpha_sender.rb
@@ -296,7 +296,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array of values that describe whether the number can receive calls or messages
+            # @return [Array[String]] An array of values that describe whether the number can receive calls or messages
             def capabilities
               @properties['capabilities']
             end

--- a/lib/twilio-ruby/rest/messaging/v1/service/phone_number.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service/phone_number.rb
@@ -302,7 +302,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array of values that describe whether the number can receive calls or messages
+            # @return [Array[String]] An array of values that describe whether the number can receive calls or messages
             def capabilities
               @properties['capabilities']
             end

--- a/lib/twilio-ruby/rest/messaging/v1/service/short_code.rb
+++ b/lib/twilio-ruby/rest/messaging/v1/service/short_code.rb
@@ -297,7 +297,7 @@ module Twilio
             end
 
             ##
-            # @return [String] An array of values that describe whether the number can receive calls or messages
+            # @return [Array[String]] An array of values that describe whether the number can receive calls or messages
             def capabilities
               @properties['capabilities']
             end

--- a/lib/twilio-ruby/rest/notify/v1/service/binding.rb
+++ b/lib/twilio-ruby/rest/notify/v1/service/binding.rb
@@ -41,8 +41,9 @@ module Twilio
             #   token. For FCM and GCM, the registration token. For SMS, a phone number in E.164
             #   format. For Facebook Messenger, the Messenger ID of the user or a phone number
             #   in E.164 format.
-            # @param [String] tag A tag that can be used to select the Bindings to notify.
-            #   Repeat this parameter to specify more than one tag, up to a total of 20 tags.
+            # @param [Array[String]] tag A tag that can be used to select the Bindings to
+            #   notify. Repeat this parameter to specify more than one tag, up to a total of 20
+            #   tags.
             # @param [String] notification_protocol_version The protocol version to use to
             #   send the notification. This defaults to the value of
             #   `default_xxxx_notification_protocol_version` for the protocol in the
@@ -81,12 +82,12 @@ module Twilio
             #   date. Specify the date in GMT and format as `YYYY-MM-DD`.
             # @param [Date] end_date Only include usage that occurred on or before this date.
             #   Specify the date in GMT and format as `YYYY-MM-DD`.
-            # @param [String] identity The
+            # @param [Array[String]] identity The
             #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
             #   of the resources to read.
-            # @param [String] tag Only list Bindings that have all of the specified Tags. The
-            #   following implicit tags are available: `all`, `apn`, `fcm`, `gcm`, `sms`,
-            #   `facebook-messenger`. Up to 5 tags are allowed.
+            # @param [Array[String]] tag Only list Bindings that have all of the specified
+            #   Tags. The following implicit tags are available: `all`, `apn`, `fcm`, `gcm`,
+            #   `sms`, `facebook-messenger`. Up to 5 tags are allowed.
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit.  Default is no limit
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -113,12 +114,12 @@ module Twilio
             #   date. Specify the date in GMT and format as `YYYY-MM-DD`.
             # @param [Date] end_date Only include usage that occurred on or before this date.
             #   Specify the date in GMT and format as `YYYY-MM-DD`.
-            # @param [String] identity The
+            # @param [Array[String]] identity The
             #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
             #   of the resources to read.
-            # @param [String] tag Only list Bindings that have all of the specified Tags. The
-            #   following implicit tags are available: `all`, `apn`, `fcm`, `gcm`, `sms`,
-            #   `facebook-messenger`. Up to 5 tags are allowed.
+            # @param [Array[String]] tag Only list Bindings that have all of the specified
+            #   Tags. The following implicit tags are available: `all`, `apn`, `fcm`, `gcm`,
+            #   `sms`, `facebook-messenger`. Up to 5 tags are allowed.
             # @param [Integer] limit Upper limit for the number of records to return. stream()
             #    guarantees to never return more than limit. Default is no limit.
             # @param [Integer] page_size Number of records to fetch per request, when
@@ -161,12 +162,12 @@ module Twilio
             #   date. Specify the date in GMT and format as `YYYY-MM-DD`.
             # @param [Date] end_date Only include usage that occurred on or before this date.
             #   Specify the date in GMT and format as `YYYY-MM-DD`.
-            # @param [String] identity The
+            # @param [Array[String]] identity The
             #   {User}[https://www.twilio.com/docs/chat/rest/user-resource]'s `identity` value
             #   of the resources to read.
-            # @param [String] tag Only list Bindings that have all of the specified Tags. The
-            #   following implicit tags are available: `all`, `apn`, `fcm`, `gcm`, `sms`,
-            #   `facebook-messenger`. Up to 5 tags are allowed.
+            # @param [Array[String]] tag Only list Bindings that have all of the specified
+            #   Tags. The following implicit tags are available: `all`, `apn`, `fcm`, `gcm`,
+            #   `sms`, `facebook-messenger`. Up to 5 tags are allowed.
             # @param [String] page_token PageToken provided by the API
             # @param [Integer] page_number Page Number, this value is simply for client state
             # @param [Integer] page_size Number of records to return, defaults to 50
@@ -406,7 +407,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of tags associated with this Binding
+            # @return [Array[String]] The list of tags associated with this Binding
             def tags
               @properties['tags']
             end

--- a/lib/twilio-ruby/rest/notify/v1/service/notification.rb
+++ b/lib/twilio-ruby/rest/notify/v1/service/notification.rb
@@ -107,24 +107,24 @@ module Twilio
             #   FCM also {reserves certain
             #   keys}[https://firebase.google.com/docs/cloud-messaging/http-server-ref], which
             #   cannot be used in that channel.
-            # @param [String] segment The Segment resource is deprecated. Use the `tag`
+            # @param [Array[String]] segment The Segment resource is deprecated. Use the `tag`
             #   parameter, instead.
             # @param [Hash] alexa Deprecated.
-            # @param [String] to_binding The destination address specified as a JSON string.
-            #   Multiple `to_binding` parameters can be included but the total size of the
-            #   request entity should not exceed 1MB. This is typically sufficient for 10,000
-            #   phone numbers.
+            # @param [Array[String]] to_binding The destination address specified as a JSON
+            #   string.  Multiple `to_binding` parameters can be included but the total size of
+            #   the request entity should not exceed 1MB. This is typically sufficient for
+            #   10,000 phone numbers.
             # @param [String] delivery_callback_url URL to send webhooks.
-            # @param [String] identity The `identity` value that uniquely identifies the new
-            #   resource's {User}[https://www.twilio.com/docs/chat/rest/user-resource] within
-            #   the {Service}[https://www.twilio.com/docs/notify/api/service-resource]. Delivery
-            #   will be attempted only to Bindings with an Identity in this list. No more than
-            #   20 items are allowed in this list.
-            # @param [String] tag A tag that selects the Bindings to notify. Repeat this
-            #   parameter to specify more than one tag, up to a total of 5 tags. The implicit
-            #   tag `all` is available to notify all Bindings in a Service instance. Similarly,
-            #   the implicit tags `apn`, `fcm`, `gcm`, `sms` and `facebook-messenger` are
-            #   available to notify all Bindings in a specific channel.
+            # @param [Array[String]] identity The `identity` value that uniquely identifies
+            #   the new resource's {User}[https://www.twilio.com/docs/chat/rest/user-resource]
+            #   within the {Service}[https://www.twilio.com/docs/notify/api/service-resource].
+            #   Delivery will be attempted only to Bindings with an Identity in this list. No
+            #   more than 20 items are allowed in this list.
+            # @param [Array[String]] tag A tag that selects the Bindings to notify. Repeat
+            #   this parameter to specify more than one tag, up to a total of 5 tags. The
+            #   implicit tag `all` is available to notify all Bindings in a Service instance.
+            #   Similarly, the implicit tags `apn`, `fcm`, `gcm`, `sms` and `facebook-messenger`
+            #   are available to notify all Bindings in a specific channel.
             # @return [NotificationInstance] Created NotificationInstance
             def create(body: :unset, priority: :unset, ttl: :unset, title: :unset, sound: :unset, action: :unset, data: :unset, apn: :unset, gcm: :unset, sms: :unset, facebook_messenger: :unset, fcm: :unset, segment: :unset, alexa: :unset, to_binding: :unset, delivery_callback_url: :unset, identity: :unset, tag: :unset)
               data = Twilio::Values.of({
@@ -255,19 +255,19 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of identity values of the Users to notify
+            # @return [Array[String]] The list of identity values of the Users to notify
             def identities
               @properties['identities']
             end
 
             ##
-            # @return [String] The tags that select the Bindings to notify
+            # @return [Array[String]] The tags that select the Bindings to notify
             def tags
               @properties['tags']
             end
 
             ##
-            # @return [String] The list of Segments to notify
+            # @return [Array[String]] The list of Segments to notify
             def segments
               @properties['segments']
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle/evaluation.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/bundle/evaluation.rb
@@ -263,7 +263,7 @@ module Twilio
               end
 
               ##
-              # @return [Hash] The results of the Evaluation resource
+              # @return [Array[Hash]] The results of the Evaluation resource
               def results
                 @properties['results']
               end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/end_user_type.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/end_user_type.rb
@@ -234,7 +234,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] The required information for creating an End-User.
+            # @return [Array[Hash]] The required information for creating an End-User.
             def fields
               @properties['fields']
             end

--- a/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/supporting_document_type.rb
+++ b/lib/twilio-ruby/rest/numbers/v2/regulatory_compliance/supporting_document_type.rb
@@ -234,7 +234,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] The required information for creating a Supporting Document
+            # @return [Array[Hash]] The required information for creating a Supporting Document
             def fields
               @properties['fields']
             end

--- a/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document.rb
@@ -130,9 +130,9 @@ module Twilio
 
           ##
           # Create the AuthorizationDocumentInstance
-          # @param [String] hosted_number_order_sids A list of HostedNumberOrder sids that
-          #   this AuthorizationDocument will authorize for hosting phone number capabilities
-          #   on Twilio's platform.
+          # @param [Array[String]] hosted_number_order_sids A list of HostedNumberOrder sids
+          #   that this AuthorizationDocument will authorize for hosting phone number
+          #   capabilities on Twilio's platform.
           # @param [String] address_sid A 34 character string that uniquely identifies the
           #   Address resource that is associated with this AuthorizationDocument.
           # @param [String] email Email that this AuthorizationDocument will be sent to for
@@ -141,7 +141,7 @@ module Twilio
           #   Authorization Document for this phone number.
           # @param [String] contact_phone_number The contact phone number of the person
           #   authorized to sign the Authorization Document.
-          # @param [String] cc_emails Email recipients who will be informed when an
+          # @param [Array[String]] cc_emails Email recipients who will be informed when an
           #   Authorization Document has been sent and signed.
           # @return [AuthorizationDocumentInstance] Created AuthorizationDocumentInstance
           def create(hosted_number_order_sids: nil, address_sid: nil, email: nil, contact_title: nil, contact_phone_number: nil, cc_emails: :unset)
@@ -228,14 +228,14 @@ module Twilio
 
           ##
           # Update the AuthorizationDocumentInstance
-          # @param [String] hosted_number_order_sids A list of HostedNumberOrder sids that
-          #   this AuthorizationDocument will authorize for hosting phone number capabilities
-          #   on Twilio's platform.
+          # @param [Array[String]] hosted_number_order_sids A list of HostedNumberOrder sids
+          #   that this AuthorizationDocument will authorize for hosting phone number
+          #   capabilities on Twilio's platform.
           # @param [String] address_sid A 34 character string that uniquely identifies the
           #   Address resource that is associated with this AuthorizationDocument.
           # @param [String] email Email that this AuthorizationDocument will be sent to for
           #   signing.
-          # @param [String] cc_emails Email recipients who will be informed when an
+          # @param [Array[String]] cc_emails Email recipients who will be informed when an
           #   Authorization Document has been sent and signed
           # @param [authorization_document.Status] status Status of an instance resource. It
           #   can hold one of the values: 1. opened 2. signing, 3. signed LOA, 4. canceled, 5.
@@ -360,7 +360,7 @@ module Twilio
           end
 
           ##
-          # @return [String] A list of emails.
+          # @return [Array[String]] A list of emails.
           def cc_emails
             @properties['cc_emails']
           end
@@ -398,14 +398,14 @@ module Twilio
 
           ##
           # Update the AuthorizationDocumentInstance
-          # @param [String] hosted_number_order_sids A list of HostedNumberOrder sids that
-          #   this AuthorizationDocument will authorize for hosting phone number capabilities
-          #   on Twilio's platform.
+          # @param [Array[String]] hosted_number_order_sids A list of HostedNumberOrder sids
+          #   that this AuthorizationDocument will authorize for hosting phone number
+          #   capabilities on Twilio's platform.
           # @param [String] address_sid A 34 character string that uniquely identifies the
           #   Address resource that is associated with this AuthorizationDocument.
           # @param [String] email Email that this AuthorizationDocument will be sent to for
           #   signing.
-          # @param [String] cc_emails Email recipients who will be informed when an
+          # @param [Array[String]] cc_emails Email recipients who will be informed when an
           #   Authorization Document has been sent and signed
           # @param [authorization_document.Status] status Status of an instance resource. It
           #   can hold one of the values: 1. opened 2. signing, 3. signed LOA, 4. canceled, 5.

--- a/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document/dependent_hosted_number_order.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers/authorization_document/dependent_hosted_number_order.rb
@@ -343,7 +343,7 @@ module Twilio
             end
 
             ##
-            # @return [String] A list of emails.
+            # @return [Array[String]] A list of emails.
             def cc_emails
               @properties['cc_emails']
             end
@@ -379,7 +379,7 @@ module Twilio
             end
 
             ##
-            # @return [String] List of IDs for ownership verification calls.
+            # @return [Array[String]] List of IDs for ownership verification calls.
             def verification_call_sids
               @properties['verification_call_sids']
             end

--- a/lib/twilio-ruby/rest/preview/hosted_numbers/hosted_number_order.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers/hosted_number_order.rb
@@ -175,8 +175,8 @@ module Twilio
           # @param [String] unique_name Optional. Provides a unique and addressable name to
           #   be assigned to this HostedNumberOrder, assigned by the developer, to be
           #   optionally used in addition to SID.
-          # @param [String] cc_emails Optional. A list of emails that the LOA document for
-          #   this HostedNumberOrder will be carbon copied to.
+          # @param [Array[String]] cc_emails Optional. A list of emails that the LOA
+          #   document for this HostedNumberOrder will be carbon copied to.
           # @param [String] sms_url The URL that Twilio should request when somebody sends
           #   an SMS to the phone number. This will be copied onto the IncomingPhoneNumber
           #   resource.
@@ -315,8 +315,8 @@ module Twilio
           #   used in addition to SID.
           # @param [String] email Email of the owner of this phone number that is being
           #   hosted.
-          # @param [String] cc_emails Optional. A list of emails that LOA document for this
-          #   HostedNumberOrder will be carbon copied to.
+          # @param [Array[String]] cc_emails Optional. A list of emails that LOA document
+          #   for this HostedNumberOrder will be carbon copied to.
           # @param [hosted_number_order.Status] status User can only post to
           #   `pending-verification` status to transition the HostedNumberOrder to initiate a
           #   verification call or verification of ownership with a copy of a phone bill.
@@ -513,7 +513,7 @@ module Twilio
           end
 
           ##
-          # @return [String] A list of emails.
+          # @return [Array[String]] A list of emails.
           def cc_emails
             @properties['cc_emails']
           end
@@ -555,7 +555,7 @@ module Twilio
           end
 
           ##
-          # @return [String] List of IDs for ownership verification calls.
+          # @return [Array[String]] List of IDs for ownership verification calls.
           def verification_call_sids
             @properties['verification_call_sids']
           end
@@ -583,8 +583,8 @@ module Twilio
           #   used in addition to SID.
           # @param [String] email Email of the owner of this phone number that is being
           #   hosted.
-          # @param [String] cc_emails Optional. A list of emails that LOA document for this
-          #   HostedNumberOrder will be carbon copied to.
+          # @param [Array[String]] cc_emails Optional. A list of emails that LOA document
+          #   for this HostedNumberOrder will be carbon copied to.
           # @param [hosted_number_order.Status] status User can only post to
           #   `pending-verification` status to transition the HostedNumberOrder to initiate a
           #   verification call or verification of ownership with a copy of a phone bill.

--- a/lib/twilio-ruby/rest/preview/wireless/rate_plan.rb
+++ b/lib/twilio-ruby/rest/preview/wireless/rate_plan.rb
@@ -116,7 +116,7 @@ module Twilio
           # @param [Boolean] voice_enabled The voice_enabled
           # @param [Boolean] commands_enabled The commands_enabled
           # @param [Boolean] national_roaming_enabled The national_roaming_enabled
-          # @param [String] international_roaming The international_roaming
+          # @param [Array[String]] international_roaming The international_roaming
           # @return [RatePlanInstance] Created RatePlanInstance
           def create(unique_name: :unset, friendly_name: :unset, data_enabled: :unset, data_limit: :unset, data_metering: :unset, messaging_enabled: :unset, voice_enabled: :unset, commands_enabled: :unset, national_roaming_enabled: :unset, international_roaming: :unset)
             data = Twilio::Values.of({
@@ -342,7 +342,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The international_roaming
+          # @return [Array[String]] The international_roaming
           def international_roaming
             @properties['international_roaming']
           end

--- a/lib/twilio-ruby/rest/pricing/v1/messaging/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v1/messaging/country.rb
@@ -231,13 +231,13 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of OutboundSMSPrice records
+            # @return [Array[String]] The list of OutboundSMSPrice records
             def outbound_sms_prices
               @properties['outbound_sms_prices']
             end
 
             ##
-            # @return [String] The list of InboundPrice records
+            # @return [Array[String]] The list of InboundPrice records
             def inbound_sms_prices
               @properties['inbound_sms_prices']
             end

--- a/lib/twilio-ruby/rest/pricing/v1/phone_number/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v1/phone_number/country.rb
@@ -230,7 +230,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of PhoneNumberPrices records
+            # @return [Array[String]] The list of PhoneNumberPrices records
             def phone_number_prices
               @properties['phone_number_prices']
             end

--- a/lib/twilio-ruby/rest/pricing/v1/voice/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v1/voice/country.rb
@@ -231,13 +231,13 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of OutboundPrefixPrice records
+            # @return [Array[String]] The list of OutboundPrefixPrice records
             def outbound_prefix_prices
               @properties['outbound_prefix_prices']
             end
 
             ##
-            # @return [String] The list of InboundCallPrice records
+            # @return [Array[String]] The list of InboundCallPrice records
             def inbound_call_prices
               @properties['inbound_call_prices']
             end

--- a/lib/twilio-ruby/rest/pricing/v2/voice/country.rb
+++ b/lib/twilio-ruby/rest/pricing/v2/voice/country.rb
@@ -231,13 +231,13 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of OutboundPrefixPriceWithOrigin records
+            # @return [Array[String]] The list of OutboundPrefixPriceWithOrigin records
             def outbound_prefix_prices
               @properties['outbound_prefix_prices']
             end
 
             ##
-            # @return [String] The list of InboundCallPrice records
+            # @return [Array[String]] The list of InboundCallPrice records
             def inbound_call_prices
               @properties['inbound_call_prices']
             end

--- a/lib/twilio-ruby/rest/pricing/v2/voice/number.rb
+++ b/lib/twilio-ruby/rest/pricing/v2/voice/number.rb
@@ -172,7 +172,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The list of OutboundCallPriceWithOrigin records
+            # @return [Array[String]] The list of OutboundCallPriceWithOrigin records
             def outbound_call_prices
               @properties['outbound_call_prices']
             end

--- a/lib/twilio-ruby/rest/proxy/v1/service/session.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/session.rb
@@ -125,7 +125,7 @@ module Twilio
             # @param [session.Status] status The initial status of the Session. Can be:
             #   `open`, `in-progress`, `closed`, `failed`, or `unknown`. The default is `open`
             #   on create.
-            # @param [Hash] participants The Participant objects to include in the new
+            # @param [Array[Hash]] participants The Participant objects to include in the new
             #   session.
             # @param [Boolean] fail_on_participant_conflict [Experimental] For accounts with
             #   the ProxyAllowParticipantConflict account flag, setting to true enables

--- a/lib/twilio-ruby/rest/proxy/v1/service/session/participant/message_interaction.rb
+++ b/lib/twilio-ruby/rest/proxy/v1/service/session/participant/message_interaction.rb
@@ -37,7 +37,7 @@ module Twilio
                 ##
                 # Create the MessageInteractionInstance
                 # @param [String] body The message to send to the participant
-                # @param [String] media_url Reserved. Not currently supported.
+                # @param [Array[String]] media_url Reserved. Not currently supported.
                 # @return [MessageInteractionInstance] Created MessageInteractionInstance
                 def create(body: :unset, media_url: :unset)
                   data = Twilio::Values.of({'Body' => body, 'MediaUrl' => Twilio.serialize_list(media_url) { |e| e }, })

--- a/lib/twilio-ruby/rest/serverless/v1/service/build.rb
+++ b/lib/twilio-ruby/rest/serverless/v1/service/build.rb
@@ -110,10 +110,10 @@ module Twilio
 
             ##
             # Create the BuildInstance
-            # @param [String] asset_versions The list of Asset Version resource SIDs to
+            # @param [Array[String]] asset_versions The list of Asset Version resource SIDs to
             #   include in the Build.
-            # @param [String] function_versions The list of the Function Version resource SIDs
-            #   to include in the Build.
+            # @param [Array[String]] function_versions The list of the Function Version
+            #   resource SIDs to include in the Build.
             # @param [String] dependencies A list of objects that describe the Dependencies
             #   included in the Build. Each object contains the `name` and `version` of the
             #   dependency.
@@ -298,19 +298,19 @@ module Twilio
             end
 
             ##
-            # @return [Hash] The list of Asset Version resource SIDs that are included in the Build
+            # @return [Array[Hash]] The list of Asset Version resource SIDs that are included in the Build
             def asset_versions
               @properties['asset_versions']
             end
 
             ##
-            # @return [Hash] The list of Function Version resource SIDs that are included in the Build
+            # @return [Array[Hash]] The list of Function Version resource SIDs that are included in the Build
             def function_versions
               @properties['function_versions']
             end
 
             ##
-            # @return [Hash] A list of objects that describe the Dependencies included in the Build
+            # @return [Array[Hash]] A list of objects that describe the Dependencies included in the Build
             def dependencies
               @properties['dependencies']
             end

--- a/lib/twilio-ruby/rest/studio/v2/flow.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow.rb
@@ -377,13 +377,13 @@ module Twilio
           end
 
           ##
-          # @return [Hash] List of error in the flow definition
+          # @return [Array[Hash]] List of error in the flow definition
           def errors
             @properties['errors']
           end
 
           ##
-          # @return [Hash] List of warnings in the flow definition
+          # @return [Array[Hash]] List of warnings in the flow definition
           def warnings
             @properties['warnings']
           end

--- a/lib/twilio-ruby/rest/studio/v2/flow/flow_revision.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow/flow_revision.rb
@@ -284,7 +284,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] List of error in the flow definition
+            # @return [Array[Hash]] List of error in the flow definition
             def errors
               @properties['errors']
             end

--- a/lib/twilio-ruby/rest/studio/v2/flow/test_user.rb
+++ b/lib/twilio-ruby/rest/studio/v2/flow/test_user.rb
@@ -91,7 +91,7 @@ module Twilio
 
             ##
             # Update the FlowTestUserInstance
-            # @param [String] test_users The test_users
+            # @param [Array[String]] test_users The test_users
             # @return [FlowTestUserInstance] Updated FlowTestUserInstance
             def update(test_users: nil)
               data = Twilio::Values.of({'TestUsers' => Twilio.serialize_list(test_users) { |e| e }, })
@@ -158,7 +158,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The test_users
+            # @return [Array[String]] The test_users
             def test_users
               @properties['test_users']
             end
@@ -178,7 +178,7 @@ module Twilio
 
             ##
             # Update the FlowTestUserInstance
-            # @param [String] test_users The test_users
+            # @param [Array[String]] test_users The test_users
             # @return [FlowTestUserInstance] Updated FlowTestUserInstance
             def update(test_users: nil)
               context.update(test_users: test_users, )

--- a/lib/twilio-ruby/rest/supersim/v1/network.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/network.rb
@@ -275,7 +275,7 @@ module Twilio
           end
 
           ##
-          # @return [Hash] The MCC/MNCs included in the Network resource
+          # @return [Array[Hash]] The MCC/MNCs included in the Network resource
           def identifiers
             @properties['identifiers']
           end

--- a/lib/twilio-ruby/rest/supersim/v1/network_access_profile.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/network_access_profile.rb
@@ -30,8 +30,8 @@ module Twilio
           # @param [String] unique_name An application-defined string that uniquely
           #   identifies the resource. It can be used in place of the resource's `sid` in the
           #   URL to address the resource.
-          # @param [String] networks List of Network SIDs that this Network Access Profile
-          #   will allow connections to.
+          # @param [Array[String]] networks List of Network SIDs that this Network Access
+          #   Profile will allow connections to.
           # @return [NetworkAccessProfileInstance] Created NetworkAccessProfileInstance
           def create(unique_name: :unset, networks: :unset)
             data = Twilio::Values.of({

--- a/lib/twilio-ruby/rest/supersim/v1/network_access_profile/network_access_profile_network.rb
+++ b/lib/twilio-ruby/rest/supersim/v1/network_access_profile/network_access_profile_network.rb
@@ -293,7 +293,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] The MCC/MNCs included in the resource
+            # @return [Array[Hash]] The MCC/MNCs included in the resource
             def identifiers
               @properties['identifiers']
             end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task.rb
@@ -31,10 +31,10 @@ module Twilio
             # memory before returning.
             # @param [String] priority The priority value of the Tasks to read. Returns the
             #   list of all Tasks in the Workspace with the specified priority.
-            # @param [String] assignment_status The `assignment_status` of the Tasks you want
-            #   to read. Can be: `pending`, `reserved`, `assigned`, `canceled`, `wrapping`, or
-            #   `completed`. Returns all Tasks in the Workspace with the specified
-            #   `assignment_status`.
+            # @param [Array[String]] assignment_status The `assignment_status` of the Tasks
+            #   you want to read. Can be: `pending`, `reserved`, `assigned`, `canceled`,
+            #   `wrapping`, or `completed`. Returns all Tasks in the Workspace with the
+            #   specified `assignment_status`.
             # @param [String] workflow_sid The SID of the Workflow with the Tasks to read.
             #   Returns the Tasks controlled by the Workflow identified by this SID.
             # @param [String] workflow_name The friendly name of the Workflow with the Tasks
@@ -86,10 +86,10 @@ module Twilio
             # is reached.
             # @param [String] priority The priority value of the Tasks to read. Returns the
             #   list of all Tasks in the Workspace with the specified priority.
-            # @param [String] assignment_status The `assignment_status` of the Tasks you want
-            #   to read. Can be: `pending`, `reserved`, `assigned`, `canceled`, `wrapping`, or
-            #   `completed`. Returns all Tasks in the Workspace with the specified
-            #   `assignment_status`.
+            # @param [Array[String]] assignment_status The `assignment_status` of the Tasks
+            #   you want to read. Can be: `pending`, `reserved`, `assigned`, `canceled`,
+            #   `wrapping`, or `completed`. Returns all Tasks in the Workspace with the
+            #   specified `assignment_status`.
             # @param [String] workflow_sid The SID of the Workflow with the Tasks to read.
             #   Returns the Tasks controlled by the Workflow identified by this SID.
             # @param [String] workflow_name The friendly name of the Workflow with the Tasks
@@ -157,10 +157,10 @@ module Twilio
             # Request is executed immediately.
             # @param [String] priority The priority value of the Tasks to read. Returns the
             #   list of all Tasks in the Workspace with the specified priority.
-            # @param [String] assignment_status The `assignment_status` of the Tasks you want
-            #   to read. Can be: `pending`, `reserved`, `assigned`, `canceled`, `wrapping`, or
-            #   `completed`. Returns all Tasks in the Workspace with the specified
-            #   `assignment_status`.
+            # @param [Array[String]] assignment_status The `assignment_status` of the Tasks
+            #   you want to read. Can be: `pending`, `reserved`, `assigned`, `canceled`,
+            #   `wrapping`, or `completed`. Returns all Tasks in the Workspace with the
+            #   specified `assignment_status`.
             # @param [String] workflow_sid The SID of the Workflow with the Tasks to read.
             #   Returns the Tasks controlled by the Workflow identified by this SID.
             # @param [String] workflow_name The friendly name of the Workflow with the Tasks

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task/reservation.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task/reservation.rb
@@ -244,8 +244,8 @@ module Twilio
               #   `status_callback_method` to send status information to your application.
               # @param [String] status_callback_method The HTTP method we should use to call
               #   `status_callback`. Can be: `POST` or `GET` and the default is `POST`.
-              # @param [reservation.CallStatus] status_callback_event The call progress events
-              #   that we will send to `status_callback`. Can be: `initiated`, `ringing`,
+              # @param [Array[reservation.CallStatus]] status_callback_event The call progress
+              #   events that we will send to `status_callback`. Can be: `initiated`, `ringing`,
               #   `answered`, or `completed`.
               # @param [String] timeout Timeout for call when executing a Conference
               #   instruction.
@@ -282,7 +282,7 @@ module Twilio
               # @param [String] conference_status_callback_method The HTTP method we should use
               #   to call `conference_status_callback`. Can be: `GET` or `POST` and defaults to
               #   `POST`.
-              # @param [reservation.ConferenceEvent] conference_status_callback_event The
+              # @param [Array[reservation.ConferenceEvent]] conference_status_callback_event The
               #   conference status events that we will send to `conference_status_callback`. Can
               #   be: `start`, `end`, `join`, `leave`, `mute`, `hold`, `speaker`.
               # @param [String] conference_record Whether to record the conference the
@@ -310,8 +310,8 @@ module Twilio
               #   `br1`, `au1`, or `jp1`.
               # @param [String] sip_auth_username The SIP username used for authentication.
               # @param [String] sip_auth_password The SIP password for authentication.
-              # @param [String] dequeue_status_callback_event The Call progress events sent via
-              #   webhooks as a result of a Dequeue instruction.
+              # @param [Array[String]] dequeue_status_callback_event The Call progress events
+              #   sent via webhooks as a result of a Dequeue instruction.
               # @param [String] post_work_activity_sid The new worker activity SID after
               #   executing a Conference instruction.
               # @param [reservation.SupervisorMode] supervisor_mode The Supervisor mode when
@@ -584,8 +584,8 @@ module Twilio
               #   `status_callback_method` to send status information to your application.
               # @param [String] status_callback_method The HTTP method we should use to call
               #   `status_callback`. Can be: `POST` or `GET` and the default is `POST`.
-              # @param [reservation.CallStatus] status_callback_event The call progress events
-              #   that we will send to `status_callback`. Can be: `initiated`, `ringing`,
+              # @param [Array[reservation.CallStatus]] status_callback_event The call progress
+              #   events that we will send to `status_callback`. Can be: `initiated`, `ringing`,
               #   `answered`, or `completed`.
               # @param [String] timeout Timeout for call when executing a Conference
               #   instruction.
@@ -622,7 +622,7 @@ module Twilio
               # @param [String] conference_status_callback_method The HTTP method we should use
               #   to call `conference_status_callback`. Can be: `GET` or `POST` and defaults to
               #   `POST`.
-              # @param [reservation.ConferenceEvent] conference_status_callback_event The
+              # @param [Array[reservation.ConferenceEvent]] conference_status_callback_event The
               #   conference status events that we will send to `conference_status_callback`. Can
               #   be: `start`, `end`, `join`, `leave`, `mute`, `hold`, `speaker`.
               # @param [String] conference_record Whether to record the conference the
@@ -650,8 +650,8 @@ module Twilio
               #   `br1`, `au1`, or `jp1`.
               # @param [String] sip_auth_username The SIP username used for authentication.
               # @param [String] sip_auth_password The SIP password for authentication.
-              # @param [String] dequeue_status_callback_event The Call progress events sent via
-              #   webhooks as a result of a Dequeue instruction.
+              # @param [Array[String]] dequeue_status_callback_event The Call progress events
+              #   sent via webhooks as a result of a Dequeue instruction.
               # @param [String] post_work_activity_sid The new worker activity SID after
               #   executing a Conference instruction.
               # @param [reservation.SupervisorMode] supervisor_mode The Supervisor mode when

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/task_queue/task_queue_real_time_statistics.rb
@@ -178,7 +178,7 @@ module Twilio
               end
 
               ##
-              # @return [Hash] The number of current Workers by Activity
+              # @return [Array[Hash]] The number of current Workers by Activity
               def activity_statistics
                 @properties['activity_statistics']
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/reservation.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/reservation.rb
@@ -246,8 +246,8 @@ module Twilio
               #   `status_callback_method` to send status information to your application.
               # @param [String] status_callback_method The HTTP method we should use to call
               #   `status_callback`. Can be: `POST` or `GET` and the default is `POST`.
-              # @param [reservation.CallStatus] status_callback_event The call progress events
-              #   that we will send to `status_callback`. Can be: `initiated`, `ringing`,
+              # @param [Array[reservation.CallStatus]] status_callback_event The call progress
+              #   events that we will send to `status_callback`. Can be: `initiated`, `ringing`,
               #   `answered`, or `completed`.
               # @param [String] timeout The timeout for a call when executing a Conference
               #   instruction.
@@ -286,7 +286,7 @@ module Twilio
               # @param [String] conference_status_callback_method The HTTP method we should use
               #   to call `conference_status_callback`. Can be: `GET` or `POST` and defaults to
               #   `POST`.
-              # @param [reservation.ConferenceEvent] conference_status_callback_event The
+              # @param [Array[reservation.ConferenceEvent]] conference_status_callback_event The
               #   conference status events that we will send to `conference_status_callback`. Can
               #   be: `start`, `end`, `join`, `leave`, `mute`, `hold`, `speaker`.
               # @param [String] conference_record Whether to record the conference the
@@ -314,8 +314,8 @@ module Twilio
               #   `br1`, `au1`, or `jp1`.
               # @param [String] sip_auth_username The SIP username used for authentication.
               # @param [String] sip_auth_password The SIP password for authentication.
-              # @param [String] dequeue_status_callback_event The call progress events sent via
-              #   webhooks as a result of a Dequeue instruction.
+              # @param [Array[String]] dequeue_status_callback_event The call progress events
+              #   sent via webhooks as a result of a Dequeue instruction.
               # @param [String] post_work_activity_sid The new worker activity SID after
               #   executing a Conference instruction.
               # @param [Boolean] end_conference_on_customer_exit Whether to end the conference
@@ -584,8 +584,8 @@ module Twilio
               #   `status_callback_method` to send status information to your application.
               # @param [String] status_callback_method The HTTP method we should use to call
               #   `status_callback`. Can be: `POST` or `GET` and the default is `POST`.
-              # @param [reservation.CallStatus] status_callback_event The call progress events
-              #   that we will send to `status_callback`. Can be: `initiated`, `ringing`,
+              # @param [Array[reservation.CallStatus]] status_callback_event The call progress
+              #   events that we will send to `status_callback`. Can be: `initiated`, `ringing`,
               #   `answered`, or `completed`.
               # @param [String] timeout The timeout for a call when executing a Conference
               #   instruction.
@@ -624,7 +624,7 @@ module Twilio
               # @param [String] conference_status_callback_method The HTTP method we should use
               #   to call `conference_status_callback`. Can be: `GET` or `POST` and defaults to
               #   `POST`.
-              # @param [reservation.ConferenceEvent] conference_status_callback_event The
+              # @param [Array[reservation.ConferenceEvent]] conference_status_callback_event The
               #   conference status events that we will send to `conference_status_callback`. Can
               #   be: `start`, `end`, `join`, `leave`, `mute`, `hold`, `speaker`.
               # @param [String] conference_record Whether to record the conference the
@@ -652,8 +652,8 @@ module Twilio
               #   `br1`, `au1`, or `jp1`.
               # @param [String] sip_auth_username The SIP username used for authentication.
               # @param [String] sip_auth_password The SIP password for authentication.
-              # @param [String] dequeue_status_callback_event The call progress events sent via
-              #   webhooks as a result of a Dequeue instruction.
+              # @param [Array[String]] dequeue_status_callback_event The call progress events
+              #   sent via webhooks as a result of a Dequeue instruction.
               # @param [String] post_work_activity_sid The new worker activity SID after
               #   executing a Conference instruction.
               # @param [Boolean] end_conference_on_customer_exit Whether to end the conference

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_cumulative_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_cumulative_statistics.rb
@@ -180,7 +180,7 @@ module Twilio
               end
 
               ##
-              # @return [Hash] The minimum, average, maximum, and total time that Workers spent in each Activity
+              # @return [Array[Hash]] The minimum, average, maximum, and total time that Workers spent in each Activity
               def activity_durations
                 @properties['activity_durations']
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/worker/workers_real_time_statistics.rb
@@ -149,7 +149,7 @@ module Twilio
               end
 
               ##
-              # @return [Hash] The number of current Workers by Activity
+              # @return [Array[Hash]] The number of current Workers by Activity
               def activity_statistics
                 @properties['activity_statistics']
               end

--- a/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_real_time_statistics.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1/workspace/workspace_real_time_statistics.rb
@@ -150,7 +150,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] The number of current Workers by Activity
+            # @return [Array[Hash]] The number of current Workers by Activity
             def activity_statistics
               @properties['activity_statistics']
             end

--- a/lib/twilio-ruby/rest/trunking/v1/trunk.rb
+++ b/lib/twilio-ruby/rest/trunking/v1/trunk.rb
@@ -476,7 +476,7 @@ module Twilio
           end
 
           ##
-          # @return [String] Reserved
+          # @return [Array[String]] Reserved
           def auth_type_set
             @properties['auth_type_set']
           end

--- a/lib/twilio-ruby/rest/verify/v2/service/entity/challenge.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/entity/challenge.rb
@@ -39,9 +39,9 @@ module Twilio
               #   minutes after creation.
               # @param [String] details_message Shown to the user when the push notification
               #   arrives. Required when `factor_type` is `push`
-              # @param [Hash] details_fields A list of objects that describe the Fields included
-              #   in the Challenge. Each object contains the label and value of the field. Used
-              #   when `factor_type` is `push`.
+              # @param [Array[Hash]] details_fields A list of objects that describe the Fields
+              #   included in the Challenge. Each object contains the label and value of the
+              #   field. Used when `factor_type` is `push`.
               # @param [Hash] hidden_details Details provided to give context about the
               #   Challenge. Not shown to the end user. It must be a stringified JSON with only
               #   strings values eg. `{"ip": "172.168.1.234"}`

--- a/lib/twilio-ruby/rest/verify/v2/service/verification.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/verification.rb
@@ -296,7 +296,7 @@ module Twilio
             end
 
             ##
-            # @return [Hash] An array of verification attempt objects.
+            # @return [Array[Hash]] An array of verification attempt objects.
             def send_code_attempts
               @properties['send_code_attempts']
             end

--- a/lib/twilio-ruby/rest/verify/v2/service/webhook.rb
+++ b/lib/twilio-ruby/rest/verify/v2/service/webhook.rb
@@ -31,9 +31,9 @@ module Twilio
             # Create the WebhookInstance
             # @param [String] friendly_name The string that you assigned to describe the
             #   webhook. **This value should not contain PII.**
-            # @param [String] event_types The array of events that this Webhook is subscribed
-            #   to. Possible event types: `*, factor.deleted, factor.created, factor.verified,
-            #   challenge.approved, challenge.denied`
+            # @param [Array[String]] event_types The array of events that this Webhook is
+            #   subscribed to. Possible event types: `*, factor.deleted, factor.created,
+            #   factor.verified, challenge.approved, challenge.denied`
             # @param [String] webhook_url The URL associated with this Webhook.
             # @param [webhook.Status] status The webhook status. Default value is `enabled`.
             #   One of: `enabled` or `disabled`
@@ -191,9 +191,9 @@ module Twilio
             # Update the WebhookInstance
             # @param [String] friendly_name The string that you assigned to describe the
             #   webhook. **This value should not contain PII.**
-            # @param [String] event_types The array of events that this Webhook is subscribed
-            #   to. Possible event types: `*, factor.deleted, factor.created, factor.verified,
-            #   challenge.approved, challenge.denied`
+            # @param [Array[String]] event_types The array of events that this Webhook is
+            #   subscribed to. Possible event types: `*, factor.deleted, factor.created,
+            #   factor.verified, challenge.approved, challenge.denied`
             # @param [String] webhook_url The URL associated with this Webhook.
             # @param [webhook.Status] status The webhook status. Default value is `enabled`.
             #   One of: `enabled` or `disabled`
@@ -312,7 +312,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The array of events that this Webhook is subscribed to.
+            # @return [Array[String]] The array of events that this Webhook is subscribed to.
             def event_types
               @properties['event_types']
             end
@@ -357,9 +357,9 @@ module Twilio
             # Update the WebhookInstance
             # @param [String] friendly_name The string that you assigned to describe the
             #   webhook. **This value should not contain PII.**
-            # @param [String] event_types The array of events that this Webhook is subscribed
-            #   to. Possible event types: `*, factor.deleted, factor.created, factor.verified,
-            #   challenge.approved, challenge.denied`
+            # @param [Array[String]] event_types The array of events that this Webhook is
+            #   subscribed to. Possible event types: `*, factor.deleted, factor.created,
+            #   factor.verified, challenge.approved, challenge.denied`
             # @param [String] webhook_url The URL associated with this Webhook.
             # @param [webhook.Status] status The webhook status. Default value is `enabled`.
             #   One of: `enabled` or `disabled`

--- a/lib/twilio-ruby/rest/video/v1/composition.rb
+++ b/lib/twilio-ruby/rest/video/v1/composition.rb
@@ -155,20 +155,21 @@ module Twilio
           #   Layouts}[https://www.twilio.com/docs/video/api/compositions-resource#specifying-video-layouts]
           #   for more info. Please, be aware that either video_layout or audio_sources have
           #   to be provided to get a valid creation request
-          # @param [String] audio_sources An array of track names from the same group room
-          #   to merge into the new composition. Can include zero or more track names. The new
-          #   composition includes all audio sources specified in `audio_sources` except for
-          #   those specified in `audio_sources_excluded`. The track names in this parameter
-          #   can include an asterisk as a wild card character, which will match zero or more
-          #   characters in a track name. For example, `student*` includes `student` as well
-          #   as `studentTeam`. Please, be aware that either video_layout or audio_sources
-          #   have to be provided to get a valid creation request
-          # @param [String] audio_sources_excluded An array of track names to exclude. The
-          #   new composition includes all audio sources specified in `audio_sources` except
-          #   for those specified in `audio_sources_excluded`. The track names in this
+          # @param [Array[String]] audio_sources An array of track names from the same group
+          #   room to merge into the new composition. Can include zero or more track names.
+          #   The new composition includes all audio sources specified in `audio_sources`
+          #   except for those specified in `audio_sources_excluded`. The track names in this
           #   parameter can include an asterisk as a wild card character, which will match
-          #   zero or more characters in a track name. For example, `student*` excludes
-          #   `student` as well as `studentTeam`. This parameter can also be empty.
+          #   zero or more characters in a track name. For example, `student*` includes
+          #   `student` as well as `studentTeam`. Please, be aware that either video_layout or
+          #   audio_sources have to be provided to get a valid creation request
+          # @param [Array[String]] audio_sources_excluded An array of track names to
+          #   exclude. The new composition includes all audio sources specified in
+          #   `audio_sources` except for those specified in `audio_sources_excluded`. The
+          #   track names in this parameter can include an asterisk as a wild card character,
+          #   which will match zero or more characters in a track name. For example,
+          #   `student*` excludes `student` as well as `studentTeam`. This parameter can also
+          #   be empty.
           # @param [String] resolution A string that describes the columns (width) and rows
           #   (height) of the generated composed video in pixels. Defaults to `640x480`.
           #   The string's format is `{width}x{height}` where:
@@ -404,13 +405,13 @@ module Twilio
           end
 
           ##
-          # @return [String] The array of track names to include in the composition
+          # @return [Array[String]] The array of track names to include in the composition
           def audio_sources
             @properties['audio_sources']
           end
 
           ##
-          # @return [String] The array of track names to exclude from the composition
+          # @return [Array[String]] The array of track names to exclude from the composition
           def audio_sources_excluded
             @properties['audio_sources_excluded']
           end

--- a/lib/twilio-ruby/rest/video/v1/composition_hook.rb
+++ b/lib/twilio-ruby/rest/video/v1/composition_hook.rb
@@ -167,17 +167,17 @@ module Twilio
           #   composition hook in terms of regions. See {Specifying Video
           #   Layouts}[https://www.twilio.com/docs/video/api/compositions-resource#specifying-video-layouts]
           #   for more info.
-          # @param [String] audio_sources An array of track names from the same group room
-          #   to merge into the compositions created by the composition hook. Can include zero
-          #   or more track names. A composition triggered by the composition hook includes
-          #   all audio sources specified in `audio_sources` except those specified in
-          #   `audio_sources_excluded`. The track names in this parameter can include an
+          # @param [Array[String]] audio_sources An array of track names from the same group
+          #   room to merge into the compositions created by the composition hook. Can include
+          #   zero or more track names. A composition triggered by the composition hook
+          #   includes all audio sources specified in `audio_sources` except those specified
+          #   in `audio_sources_excluded`. The track names in this parameter can include an
           #   asterisk as a wild card character, which matches zero or more characters in a
           #   track name. For example, `student*` includes tracks named `student` as well as
           #   `studentTeam`.
-          # @param [String] audio_sources_excluded An array of track names to exclude. A
-          #   composition triggered by the composition hook includes all audio sources
-          #   specified in `audio_sources` except for those specified in
+          # @param [Array[String]] audio_sources_excluded An array of track names to
+          #   exclude. A composition triggered by the composition hook includes all audio
+          #   sources specified in `audio_sources` except for those specified in
           #   `audio_sources_excluded`. The track names in this parameter can include an
           #   asterisk as a wild card character, which matches zero or more characters in a
           #   track name. For example, `student*` excludes `student` as well as `studentTeam`.
@@ -323,17 +323,17 @@ module Twilio
           #   composition hook in terms of regions. See {Specifying Video
           #   Layouts}[https://www.twilio.com/docs/video/api/compositions-resource#specifying-video-layouts]
           #   for more info.
-          # @param [String] audio_sources An array of track names from the same group room
-          #   to merge into the compositions created by the composition hook. Can include zero
-          #   or more track names. A composition triggered by the composition hook includes
-          #   all audio sources specified in `audio_sources` except those specified in
-          #   `audio_sources_excluded`. The track names in this parameter can include an
+          # @param [Array[String]] audio_sources An array of track names from the same group
+          #   room to merge into the compositions created by the composition hook. Can include
+          #   zero or more track names. A composition triggered by the composition hook
+          #   includes all audio sources specified in `audio_sources` except those specified
+          #   in `audio_sources_excluded`. The track names in this parameter can include an
           #   asterisk as a wild card character, which matches zero or more characters in a
           #   track name. For example, `student*` includes tracks named `student` as well as
           #   `studentTeam`.
-          # @param [String] audio_sources_excluded An array of track names to exclude. A
-          #   composition triggered by the composition hook includes all audio sources
-          #   specified in `audio_sources` except for those specified in
+          # @param [Array[String]] audio_sources_excluded An array of track names to
+          #   exclude. A composition triggered by the composition hook includes all audio
+          #   sources specified in `audio_sources` except for those specified in
           #   `audio_sources_excluded`. The track names in this parameter can include an
           #   asterisk as a wild card character, which matches zero or more characters in a
           #   track name. For example, `student*` excludes `student` as well as `studentTeam`.
@@ -496,13 +496,13 @@ module Twilio
           end
 
           ##
-          # @return [String] The array of track names to include in the compositions created by the composition hook
+          # @return [Array[String]] The array of track names to include in the compositions created by the composition hook
           def audio_sources
             @properties['audio_sources']
           end
 
           ##
-          # @return [String] The array of track names to exclude from the compositions created by the composition hook
+          # @return [Array[String]] The array of track names to exclude from the compositions created by the composition hook
           def audio_sources_excluded
             @properties['audio_sources_excluded']
           end
@@ -575,17 +575,17 @@ module Twilio
           #   composition hook in terms of regions. See {Specifying Video
           #   Layouts}[https://www.twilio.com/docs/video/api/compositions-resource#specifying-video-layouts]
           #   for more info.
-          # @param [String] audio_sources An array of track names from the same group room
-          #   to merge into the compositions created by the composition hook. Can include zero
-          #   or more track names. A composition triggered by the composition hook includes
-          #   all audio sources specified in `audio_sources` except those specified in
-          #   `audio_sources_excluded`. The track names in this parameter can include an
+          # @param [Array[String]] audio_sources An array of track names from the same group
+          #   room to merge into the compositions created by the composition hook. Can include
+          #   zero or more track names. A composition triggered by the composition hook
+          #   includes all audio sources specified in `audio_sources` except those specified
+          #   in `audio_sources_excluded`. The track names in this parameter can include an
           #   asterisk as a wild card character, which matches zero or more characters in a
           #   track name. For example, `student*` includes tracks named `student` as well as
           #   `studentTeam`.
-          # @param [String] audio_sources_excluded An array of track names to exclude. A
-          #   composition triggered by the composition hook includes all audio sources
-          #   specified in `audio_sources` except for those specified in
+          # @param [Array[String]] audio_sources_excluded An array of track names to
+          #   exclude. A composition triggered by the composition hook includes all audio
+          #   sources specified in `audio_sources` except for those specified in
           #   `audio_sources_excluded`. The track names in this parameter can include an
           #   asterisk as a wild card character, which matches zero or more characters in a
           #   track name. For example, `student*` excludes `student` as well as `studentTeam`.

--- a/lib/twilio-ruby/rest/video/v1/recording.rb
+++ b/lib/twilio-ruby/rest/video/v1/recording.rb
@@ -30,8 +30,8 @@ module Twilio
           # @param [recording.Status] status Read only the recordings that have this status.
           #   Can be: `processing`, `completed`, or `deleted`.
           # @param [String] source_sid Read only the recordings that have this `source_sid`.
-          # @param [String] grouping_sid Read only recordings with this `grouping_sid`,
-          #   which may include a `participant_sid` and/or a `room_sid`.
+          # @param [Array[String]] grouping_sid Read only recordings with this
+          #   `grouping_sid`, which may include a `participant_sid` and/or a `room_sid`.
           # @param [Time] date_created_after Read only recordings that started on or after
           #   this {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601] date-time with time
           #   zone.
@@ -67,8 +67,8 @@ module Twilio
           # @param [recording.Status] status Read only the recordings that have this status.
           #   Can be: `processing`, `completed`, or `deleted`.
           # @param [String] source_sid Read only the recordings that have this `source_sid`.
-          # @param [String] grouping_sid Read only recordings with this `grouping_sid`,
-          #   which may include a `participant_sid` and/or a `room_sid`.
+          # @param [Array[String]] grouping_sid Read only recordings with this
+          #   `grouping_sid`, which may include a `participant_sid` and/or a `room_sid`.
           # @param [Time] date_created_after Read only recordings that started on or after
           #   this {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601] date-time with time
           #   zone.
@@ -120,8 +120,8 @@ module Twilio
           # @param [recording.Status] status Read only the recordings that have this status.
           #   Can be: `processing`, `completed`, or `deleted`.
           # @param [String] source_sid Read only the recordings that have this `source_sid`.
-          # @param [String] grouping_sid Read only recordings with this `grouping_sid`,
-          #   which may include a `participant_sid` and/or a `room_sid`.
+          # @param [Array[String]] grouping_sid Read only recordings with this
+          #   `grouping_sid`, which may include a `participant_sid` and/or a `room_sid`.
           # @param [Time] date_created_after Read only recordings that started on or after
           #   this {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601] date-time with time
           #   zone.

--- a/lib/twilio-ruby/rest/video/v1/room.rb
+++ b/lib/twilio-ruby/rest/video/v1/room.rb
@@ -48,8 +48,8 @@ module Twilio
           # @param [Boolean] record_participants_on_connect Whether to start recording when
           #   Participants connect. ***This feature is not available in `peer-to-peer`
           #   rooms.***
-          # @param [room.VideoCodec] video_codecs An array of the video codecs that are
-          #   supported when publishing a track in the room.  Can be: `VP8` and `H264`.
+          # @param [Array[room.VideoCodec]] video_codecs An array of the video codecs that
+          #   are supported when publishing a track in the room.  Can be: `VP8` and `H264`.
           #   ***This feature is not available in `peer-to-peer` rooms***
           # @param [String] media_region The region for the media server in Group Rooms.
           #   Can be: one of the {available Media
@@ -465,7 +465,7 @@ module Twilio
           end
 
           ##
-          # @return [room.VideoCodec] An array of the video codecs that are supported when publishing a track in the room
+          # @return [Array[room.VideoCodec]] An array of the video codecs that are supported when publishing a track in the room
           def video_codecs
             @properties['video_codecs']
           end

--- a/lib/twilio-ruby/rest/video/v1/room/room_participant/room_participant_subscribe_rule.rb
+++ b/lib/twilio-ruby/rest/video/v1/room/room_participant/room_participant_subscribe_rule.rb
@@ -138,7 +138,7 @@ module Twilio
               end
 
               ##
-              # @return [String] A collection of Subscribe Rules that describe how to include or exclude matching tracks
+              # @return [Array[String]] A collection of Subscribe Rules that describe how to include or exclude matching tracks
               def rules
                 @properties['rules']
               end

--- a/lib/twilio-ruby/rest/video/v1/room/room_recording_rule.rb
+++ b/lib/twilio-ruby/rest/video/v1/room/room_recording_rule.rb
@@ -114,7 +114,7 @@ module Twilio
             end
 
             ##
-            # @return [String] A collection of recording Rules that describe how to include or exclude matching tracks for recording
+            # @return [Array[String]] A collection of recording Rules that describe how to include or exclude matching tracks for recording
             def rules
               @properties['rules']
             end

--- a/lib/twilio-ruby/rest/voice/v1/dialing_permissions/country.rb
+++ b/lib/twilio-ruby/rest/voice/v1/dialing_permissions/country.rb
@@ -334,7 +334,7 @@ module Twilio
             end
 
             ##
-            # @return [String] The E.164 assigned country codes(s)
+            # @return [Array[String]] The E.164 assigned country codes(s)
             def country_codes
               @properties['country_codes']
             end

--- a/lib/twilio-ruby/rest/wireless/v1/rate_plan.rb
+++ b/lib/twilio-ruby/rest/wireless/v1/rate_plan.rb
@@ -127,9 +127,9 @@ module Twilio
           # @param [Boolean] national_roaming_enabled Whether SIMs can roam on networks
           #   other than the home network (T-Mobile USA) in the United States. See {national
           #   roaming}[https://www.twilio.com/docs/wireless/api/rateplan-resource#national-roaming].
-          # @param [String] international_roaming The list of services that SIMs capable of
-          #   using GPRS/3G/4G/LTE data connectivity can use outside of the United States. Can
-          #   be: `data`, `voice`, and `messaging`.
+          # @param [Array[String]] international_roaming The list of services that SIMs
+          #   capable of using GPRS/3G/4G/LTE data connectivity can use outside of the United
+          #   States. Can be: `data`, `voice`, and `messaging`.
           # @param [String] national_roaming_data_limit The total data usage (download and
           #   upload combined) in Megabytes that the Network allows during one month on
           #   non-home networks in the United States. The metering period begins the day of
@@ -371,7 +371,7 @@ module Twilio
           end
 
           ##
-          # @return [String] The services that SIMs capable of using GPRS/3G/4G/LTE data connectivity can use outside of the United States
+          # @return [Array[String]] The services that SIMs capable of using GPRS/3G/4G/LTE data connectivity can use outside of the United States
           def international_roaming
             @properties['international_roaming']
           end


### PR DESCRIPTION
# Fixes #

fix: fixing incorrect documentation for list property types.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
