### PR TITLE
fix: regenerating with the path parameter fix

### DIFF
--- a/lib/twilio-ruby/rest/api/v2010.rb
+++ b/lib/twilio-ruby/rest/api/v2010.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Api::V2010::AccountList]
         def accounts(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @accounts ||= AccountList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @accounts ||= AccountList.new self
           else
-            AccountContext.new(self, sid)
+              AccountContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/autopilot/v1.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Autopilot::V1::AssistantList]
         def assistants(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @assistants ||= AssistantList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @assistants ||= AssistantList.new self
           else
-            AssistantContext.new(self, sid)
+              AssistantContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/bulkexports/v1.rb
+++ b/lib/twilio-ruby/rest/bulkexports/v1.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Bulkexports::V1::ExportList]
         def exports(resource_type=:unset)
           if resource_type.nil?
-            raise ArgumentError, 'resource_type cannot be nil'
-          elsif resource_type == :unset
-            @exports ||= ExportList.new self
+              raise ArgumentError, 'resource_type cannot be nil'
+          end
+          if resource_type == :unset
+              @exports ||= ExportList.new self
           else
-            ExportContext.new(self, resource_type)
+              ExportContext.new(self, resource_type)
           end
         end
 
@@ -41,11 +42,12 @@ module Twilio
         # @return [Twilio::REST::Bulkexports::V1::ExportConfigurationList]
         def export_configuration(resource_type=:unset)
           if resource_type.nil?
-            raise ArgumentError, 'resource_type cannot be nil'
-          elsif resource_type == :unset
-            @export_configuration ||= ExportConfigurationList.new self
+              raise ArgumentError, 'resource_type cannot be nil'
+          end
+          if resource_type == :unset
+              @export_configuration ||= ExportConfigurationList.new self
           else
-            ExportConfigurationContext.new(self, resource_type)
+              ExportConfigurationContext.new(self, resource_type)
           end
         end
 

--- a/lib/twilio-ruby/rest/chat/v1.rb
+++ b/lib/twilio-ruby/rest/chat/v1.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Chat::V1::CredentialList]
         def credentials(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @credentials ||= CredentialList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @credentials ||= CredentialList.new self
           else
-            CredentialContext.new(self, sid)
+              CredentialContext.new(self, sid)
           end
         end
 
@@ -41,11 +42,12 @@ module Twilio
         # @return [Twilio::REST::Chat::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/chat/v2.rb
+++ b/lib/twilio-ruby/rest/chat/v2.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Chat::V2::CredentialList]
         def credentials(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @credentials ||= CredentialList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @credentials ||= CredentialList.new self
           else
-            CredentialContext.new(self, sid)
+              CredentialContext.new(self, sid)
           end
         end
 
@@ -39,11 +40,12 @@ module Twilio
         # @return [Twilio::REST::Chat::V2::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/conversations/v1.rb
+++ b/lib/twilio-ruby/rest/conversations/v1.rb
@@ -36,11 +36,12 @@ module Twilio
         # @return [Twilio::REST::Conversations::V1::ConversationList]
         def conversations(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @conversations ||= ConversationList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @conversations ||= ConversationList.new self
           else
-            ConversationContext.new(self, sid)
+              ConversationContext.new(self, sid)
           end
         end
 
@@ -51,11 +52,12 @@ module Twilio
         # @return [Twilio::REST::Conversations::V1::CredentialList]
         def credentials(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @credentials ||= CredentialList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @credentials ||= CredentialList.new self
           else
-            CredentialContext.new(self, sid)
+              CredentialContext.new(self, sid)
           end
         end
 
@@ -65,11 +67,12 @@ module Twilio
         # @return [Twilio::REST::Conversations::V1::RoleList]
         def roles(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @roles ||= RoleList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @roles ||= RoleList.new self
           else
-            RoleContext.new(self, sid)
+              RoleContext.new(self, sid)
           end
         end
 
@@ -80,11 +83,12 @@ module Twilio
         # @return [Twilio::REST::Conversations::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 
@@ -95,11 +99,12 @@ module Twilio
         # @return [Twilio::REST::Conversations::V1::UserList]
         def users(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @users ||= UserList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @users ||= UserList.new self
           else
-            UserContext.new(self, sid)
+              UserContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/events/v1.rb
+++ b/lib/twilio-ruby/rest/events/v1.rb
@@ -27,11 +27,12 @@ module Twilio
         # @return [Twilio::REST::Events::V1::EventTypeList]
         def event_types(type=:unset)
           if type.nil?
-            raise ArgumentError, 'type cannot be nil'
-          elsif type == :unset
-            @event_types ||= EventTypeList.new self
+              raise ArgumentError, 'type cannot be nil'
+          end
+          if type == :unset
+              @event_types ||= EventTypeList.new self
           else
-            EventTypeContext.new(self, type)
+              EventTypeContext.new(self, type)
           end
         end
 
@@ -42,11 +43,12 @@ module Twilio
         # @return [Twilio::REST::Events::V1::SchemaList]
         def schemas(id=:unset)
           if id.nil?
-            raise ArgumentError, 'id cannot be nil'
-          elsif id == :unset
-            @schemas ||= SchemaList.new self
+              raise ArgumentError, 'id cannot be nil'
+          end
+          if id == :unset
+              @schemas ||= SchemaList.new self
           else
-            SchemaContext.new(self, id)
+              SchemaContext.new(self, id)
           end
         end
 
@@ -56,11 +58,12 @@ module Twilio
         # @return [Twilio::REST::Events::V1::SinkList]
         def sinks(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @sinks ||= SinkList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @sinks ||= SinkList.new self
           else
-            SinkContext.new(self, sid)
+              SinkContext.new(self, sid)
           end
         end
 
@@ -71,11 +74,12 @@ module Twilio
         # @return [Twilio::REST::Events::V1::SubscriptionList]
         def subscriptions(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @subscriptions ||= SubscriptionList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @subscriptions ||= SubscriptionList.new self
           else
-            SubscriptionContext.new(self, sid)
+              SubscriptionContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/fax/v1.rb
+++ b/lib/twilio-ruby/rest/fax/v1.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Fax::V1::FaxList]
         def faxes(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @faxes ||= FaxList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @faxes ||= FaxList.new self
           else
-            FaxContext.new(self, sid)
+              FaxContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/flex_api/v1.rb
+++ b/lib/twilio-ruby/rest/flex_api/v1.rb
@@ -27,11 +27,12 @@ module Twilio
         # @return [Twilio::REST::Flex_api::V1::ChannelList]
         def channel(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @channel ||= ChannelList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @channel ||= ChannelList.new self
           else
-            ChannelContext.new(self, sid)
+              ChannelContext.new(self, sid)
           end
         end
 
@@ -47,11 +48,12 @@ module Twilio
         # @return [Twilio::REST::Flex_api::V1::FlexFlowList]
         def flex_flow(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @flex_flow ||= FlexFlowList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @flex_flow ||= FlexFlowList.new self
           else
-            FlexFlowContext.new(self, sid)
+              FlexFlowContext.new(self, sid)
           end
         end
 
@@ -61,11 +63,12 @@ module Twilio
         # @return [Twilio::REST::Flex_api::V1::WebChannelList]
         def web_channel(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @web_channel ||= WebChannelList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @web_channel ||= WebChannelList.new self
           else
-            WebChannelContext.new(self, sid)
+              WebChannelContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/insights/v1.rb
+++ b/lib/twilio-ruby/rest/insights/v1.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Insights::V1::CallList]
         def calls(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @calls ||= CallList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @calls ||= CallList.new self
           else
-            CallContext.new(self, sid)
+              CallContext.new(self, sid)
           end
         end
 
@@ -39,11 +40,12 @@ module Twilio
         # @return [Twilio::REST::Insights::V1::RoomList]
         def rooms(room_sid=:unset)
           if room_sid.nil?
-            raise ArgumentError, 'room_sid cannot be nil'
-          elsif room_sid == :unset
-            @rooms ||= RoomList.new self
+              raise ArgumentError, 'room_sid cannot be nil'
+          end
+          if room_sid == :unset
+              @rooms ||= RoomList.new self
           else
-            RoomContext.new(self, room_sid)
+              RoomContext.new(self, room_sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/ip_messaging/v1.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v1.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Ip_messaging::V1::CredentialList]
         def credentials(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @credentials ||= CredentialList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @credentials ||= CredentialList.new self
           else
-            CredentialContext.new(self, sid)
+              CredentialContext.new(self, sid)
           end
         end
 
@@ -39,11 +40,12 @@ module Twilio
         # @return [Twilio::REST::Ip_messaging::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/ip_messaging/v2.rb
+++ b/lib/twilio-ruby/rest/ip_messaging/v2.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Ip_messaging::V2::CredentialList]
         def credentials(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @credentials ||= CredentialList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @credentials ||= CredentialList.new self
           else
-            CredentialContext.new(self, sid)
+              CredentialContext.new(self, sid)
           end
         end
 
@@ -39,11 +40,12 @@ module Twilio
         # @return [Twilio::REST::Ip_messaging::V2::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/lookups/v1.rb
+++ b/lib/twilio-ruby/rest/lookups/v1.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Lookups::V1::PhoneNumberList]
         def phone_numbers(phone_number=:unset)
           if phone_number.nil?
-            raise ArgumentError, 'phone_number cannot be nil'
-          elsif phone_number == :unset
-            @phone_numbers ||= PhoneNumberList.new self
+              raise ArgumentError, 'phone_number cannot be nil'
+          end
+          if phone_number == :unset
+              @phone_numbers ||= PhoneNumberList.new self
           else
-            PhoneNumberContext.new(self, phone_number)
+              PhoneNumberContext.new(self, phone_number)
           end
         end
 

--- a/lib/twilio-ruby/rest/messaging/v1.rb
+++ b/lib/twilio-ruby/rest/messaging/v1.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Messaging::V1::BrandRegistrationList]
         def brand_registrations(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @brand_registrations ||= BrandRegistrationList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @brand_registrations ||= BrandRegistrationList.new self
           else
-            BrandRegistrationContext.new(self, sid)
+              BrandRegistrationContext.new(self, sid)
           end
         end
 
@@ -46,11 +47,12 @@ module Twilio
         # @return [Twilio::REST::Messaging::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/monitor/v1.rb
+++ b/lib/twilio-ruby/rest/monitor/v1.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Monitor::V1::AlertList]
         def alerts(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @alerts ||= AlertList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @alerts ||= AlertList.new self
           else
-            AlertContext.new(self, sid)
+              AlertContext.new(self, sid)
           end
         end
 
@@ -39,11 +40,12 @@ module Twilio
         # @return [Twilio::REST::Monitor::V1::EventList]
         def events(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @events ||= EventList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @events ||= EventList.new self
           else
-            EventContext.new(self, sid)
+              EventContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/notify/v1.rb
+++ b/lib/twilio-ruby/rest/notify/v1.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Notify::V1::CredentialList]
         def credentials(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @credentials ||= CredentialList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @credentials ||= CredentialList.new self
           else
-            CredentialContext.new(self, sid)
+              CredentialContext.new(self, sid)
           end
         end
 
@@ -41,11 +42,12 @@ module Twilio
         # @return [Twilio::REST::Notify::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/bulk_exports.rb
+++ b/lib/twilio-ruby/rest/preview/bulk_exports.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Preview::BulkExports::ExportList]
         def exports(resource_type=:unset)
           if resource_type.nil?
-            raise ArgumentError, 'resource_type cannot be nil'
-          elsif resource_type == :unset
-            @exports ||= ExportList.new self
+              raise ArgumentError, 'resource_type cannot be nil'
+          end
+          if resource_type == :unset
+              @exports ||= ExportList.new self
           else
-            ExportContext.new(self, resource_type)
+              ExportContext.new(self, resource_type)
           end
         end
 
@@ -41,11 +42,12 @@ module Twilio
         # @return [Twilio::REST::Preview::BulkExports::ExportConfigurationList]
         def export_configuration(resource_type=:unset)
           if resource_type.nil?
-            raise ArgumentError, 'resource_type cannot be nil'
-          elsif resource_type == :unset
-            @export_configuration ||= ExportConfigurationList.new self
+              raise ArgumentError, 'resource_type cannot be nil'
+          end
+          if resource_type == :unset
+              @export_configuration ||= ExportConfigurationList.new self
           else
-            ExportConfigurationContext.new(self, resource_type)
+              ExportConfigurationContext.new(self, resource_type)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/deployed_devices.rb
+++ b/lib/twilio-ruby/rest/preview/deployed_devices.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Preview::DeployedDevices::FleetList]
         def fleets(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @fleets ||= FleetList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @fleets ||= FleetList.new self
           else
-            FleetContext.new(self, sid)
+              FleetContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/hosted_numbers.rb
+++ b/lib/twilio-ruby/rest/preview/hosted_numbers.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Preview::HostedNumbers::AuthorizationDocumentList]
         def authorization_documents(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @authorization_documents ||= AuthorizationDocumentList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @authorization_documents ||= AuthorizationDocumentList.new self
           else
-            AuthorizationDocumentContext.new(self, sid)
+              AuthorizationDocumentContext.new(self, sid)
           end
         end
 
@@ -41,11 +42,12 @@ module Twilio
         # @return [Twilio::REST::Preview::HostedNumbers::HostedNumberOrderList]
         def hosted_number_orders(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @hosted_number_orders ||= HostedNumberOrderList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @hosted_number_orders ||= HostedNumberOrderList.new self
           else
-            HostedNumberOrderContext.new(self, sid)
+              HostedNumberOrderContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/marketplace.rb
+++ b/lib/twilio-ruby/rest/preview/marketplace.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Marketplace::AvailableAddOnList]
         def available_add_ons(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @available_add_ons ||= AvailableAddOnList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @available_add_ons ||= AvailableAddOnList.new self
           else
-            AvailableAddOnContext.new(self, sid)
+              AvailableAddOnContext.new(self, sid)
           end
         end
 
@@ -39,11 +40,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Marketplace::InstalledAddOnList]
         def installed_add_ons(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @installed_add_ons ||= InstalledAddOnList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @installed_add_ons ||= InstalledAddOnList.new self
           else
-            InstalledAddOnContext.new(self, sid)
+              InstalledAddOnContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/sync.rb
+++ b/lib/twilio-ruby/rest/preview/sync.rb
@@ -24,11 +24,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Sync::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/trusted_comms.rb
+++ b/lib/twilio-ruby/rest/preview/trusted_comms.rb
@@ -27,11 +27,12 @@ module Twilio
         # @return [Twilio::REST::Preview::TrustedComms::BrandedChannelList]
         def branded_channels(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @branded_channels ||= BrandedChannelList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @branded_channels ||= BrandedChannelList.new self
           else
-            BrandedChannelContext.new(self, sid)
+              BrandedChannelContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/understand.rb
+++ b/lib/twilio-ruby/rest/preview/understand.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Understand::AssistantList]
         def assistants(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @assistants ||= AssistantList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @assistants ||= AssistantList.new self
           else
-            AssistantContext.new(self, sid)
+              AssistantContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/preview/wireless.rb
+++ b/lib/twilio-ruby/rest/preview/wireless.rb
@@ -26,11 +26,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Wireless::CommandList]
         def commands(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @commands ||= CommandList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @commands ||= CommandList.new self
           else
-            CommandContext.new(self, sid)
+              CommandContext.new(self, sid)
           end
         end
 
@@ -40,11 +41,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Wireless::RatePlanList]
         def rate_plans(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @rate_plans ||= RatePlanList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @rate_plans ||= RatePlanList.new self
           else
-            RatePlanContext.new(self, sid)
+              RatePlanContext.new(self, sid)
           end
         end
 
@@ -54,11 +56,12 @@ module Twilio
         # @return [Twilio::REST::Preview::Wireless::SimList]
         def sims(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @sims ||= SimList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @sims ||= SimList.new self
           else
-            SimContext.new(self, sid)
+              SimContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/proxy/v1.rb
+++ b/lib/twilio-ruby/rest/proxy/v1.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Proxy::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/serverless/v1.rb
+++ b/lib/twilio-ruby/rest/serverless/v1.rb
@@ -24,11 +24,12 @@ module Twilio
         # @return [Twilio::REST::Serverless::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/studio/v1.rb
+++ b/lib/twilio-ruby/rest/studio/v1.rb
@@ -24,11 +24,12 @@ module Twilio
         # @return [Twilio::REST::Studio::V1::FlowList]
         def flows(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @flows ||= FlowList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @flows ||= FlowList.new self
           else
-            FlowContext.new(self, sid)
+              FlowContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/studio/v2.rb
+++ b/lib/twilio-ruby/rest/studio/v2.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Studio::V2::FlowList]
         def flows(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @flows ||= FlowList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @flows ||= FlowList.new self
           else
-            FlowContext.new(self, sid)
+              FlowContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/supersim/v1.rb
+++ b/lib/twilio-ruby/rest/supersim/v1.rb
@@ -29,11 +29,12 @@ module Twilio
         # @return [Twilio::REST::Supersim::V1::CommandList]
         def commands(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @commands ||= CommandList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @commands ||= CommandList.new self
           else
-            CommandContext.new(self, sid)
+              CommandContext.new(self, sid)
           end
         end
 
@@ -43,11 +44,12 @@ module Twilio
         # @return [Twilio::REST::Supersim::V1::FleetList]
         def fleets(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @fleets ||= FleetList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @fleets ||= FleetList.new self
           else
-            FleetContext.new(self, sid)
+              FleetContext.new(self, sid)
           end
         end
 
@@ -57,11 +59,12 @@ module Twilio
         # @return [Twilio::REST::Supersim::V1::NetworkList]
         def networks(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @networks ||= NetworkList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @networks ||= NetworkList.new self
           else
-            NetworkContext.new(self, sid)
+              NetworkContext.new(self, sid)
           end
         end
 
@@ -71,11 +74,12 @@ module Twilio
         # @return [Twilio::REST::Supersim::V1::NetworkAccessProfileList]
         def network_access_profiles(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @network_access_profiles ||= NetworkAccessProfileList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @network_access_profiles ||= NetworkAccessProfileList.new self
           else
-            NetworkAccessProfileContext.new(self, sid)
+              NetworkAccessProfileContext.new(self, sid)
           end
         end
 
@@ -85,11 +89,12 @@ module Twilio
         # @return [Twilio::REST::Supersim::V1::SimList]
         def sims(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @sims ||= SimList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @sims ||= SimList.new self
           else
-            SimContext.new(self, sid)
+              SimContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/sync/v1.rb
+++ b/lib/twilio-ruby/rest/sync/v1.rb
@@ -24,11 +24,12 @@ module Twilio
         # @return [Twilio::REST::Sync::V1::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/taskrouter/v1.rb
+++ b/lib/twilio-ruby/rest/taskrouter/v1.rb
@@ -24,11 +24,12 @@ module Twilio
         # @return [Twilio::REST::Taskrouter::V1::WorkspaceList]
         def workspaces(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @workspaces ||= WorkspaceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @workspaces ||= WorkspaceList.new self
           else
-            WorkspaceContext.new(self, sid)
+              WorkspaceContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/trunking/v1.rb
+++ b/lib/twilio-ruby/rest/trunking/v1.rb
@@ -25,11 +25,12 @@ module Twilio
         # @return [Twilio::REST::Trunking::V1::TrunkList]
         def trunks(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @trunks ||= TrunkList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @trunks ||= TrunkList.new self
           else
-            TrunkContext.new(self, sid)
+              TrunkContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/trusthub/v1.rb
+++ b/lib/twilio-ruby/rest/trusthub/v1.rb
@@ -31,11 +31,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::CustomerProfilesList]
         def customer_profiles(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @customer_profiles ||= CustomerProfilesList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @customer_profiles ||= CustomerProfilesList.new self
           else
-            CustomerProfilesContext.new(self, sid)
+              CustomerProfilesContext.new(self, sid)
           end
         end
 
@@ -46,11 +47,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::EndUserList]
         def end_users(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @end_users ||= EndUserList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @end_users ||= EndUserList.new self
           else
-            EndUserContext.new(self, sid)
+              EndUserContext.new(self, sid)
           end
         end
 
@@ -61,11 +63,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::EndUserTypeList]
         def end_user_types(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @end_user_types ||= EndUserTypeList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @end_user_types ||= EndUserTypeList.new self
           else
-            EndUserTypeContext.new(self, sid)
+              EndUserTypeContext.new(self, sid)
           end
         end
 
@@ -75,11 +78,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::PoliciesList]
         def policies(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @policies ||= PoliciesList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @policies ||= PoliciesList.new self
           else
-            PoliciesContext.new(self, sid)
+              PoliciesContext.new(self, sid)
           end
         end
 
@@ -90,11 +94,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::SupportingDocumentList]
         def supporting_documents(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @supporting_documents ||= SupportingDocumentList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @supporting_documents ||= SupportingDocumentList.new self
           else
-            SupportingDocumentContext.new(self, sid)
+              SupportingDocumentContext.new(self, sid)
           end
         end
 
@@ -105,11 +110,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::SupportingDocumentTypeList]
         def supporting_document_types(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @supporting_document_types ||= SupportingDocumentTypeList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @supporting_document_types ||= SupportingDocumentTypeList.new self
           else
-            SupportingDocumentTypeContext.new(self, sid)
+              SupportingDocumentTypeContext.new(self, sid)
           end
         end
 
@@ -120,11 +126,12 @@ module Twilio
         # @return [Twilio::REST::Trusthub::V1::TrustProductsList]
         def trust_products(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @trust_products ||= TrustProductsList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @trust_products ||= TrustProductsList.new self
           else
-            TrustProductsContext.new(self, sid)
+              TrustProductsContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/verify/v2.rb
+++ b/lib/twilio-ruby/rest/verify/v2.rb
@@ -27,11 +27,12 @@ module Twilio
         # @return [Twilio::REST::Verify::V2::FormList]
         def forms(form_type=:unset)
           if form_type.nil?
-            raise ArgumentError, 'form_type cannot be nil'
-          elsif form_type == :unset
-            @forms ||= FormList.new self
+              raise ArgumentError, 'form_type cannot be nil'
+          end
+          if form_type == :unset
+              @forms ||= FormList.new self
           else
-            FormContext.new(self, form_type)
+              FormContext.new(self, form_type)
           end
         end
 
@@ -42,11 +43,12 @@ module Twilio
         # @return [Twilio::REST::Verify::V2::ServiceList]
         def services(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @services ||= ServiceList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @services ||= ServiceList.new self
           else
-            ServiceContext.new(self, sid)
+              ServiceContext.new(self, sid)
           end
         end
 
@@ -56,11 +58,12 @@ module Twilio
         # @return [Twilio::REST::Verify::V2::VerificationAttemptList]
         def verification_attempts(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @verification_attempts ||= VerificationAttemptList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @verification_attempts ||= VerificationAttemptList.new self
           else
-            VerificationAttemptContext.new(self, sid)
+              VerificationAttemptContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/video/v1.rb
+++ b/lib/twilio-ruby/rest/video/v1.rb
@@ -29,11 +29,12 @@ module Twilio
         # @return [Twilio::REST::Video::V1::CompositionList]
         def compositions(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @compositions ||= CompositionList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @compositions ||= CompositionList.new self
           else
-            CompositionContext.new(self, sid)
+              CompositionContext.new(self, sid)
           end
         end
 
@@ -43,11 +44,12 @@ module Twilio
         # @return [Twilio::REST::Video::V1::CompositionHookList]
         def composition_hooks(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @composition_hooks ||= CompositionHookList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @composition_hooks ||= CompositionHookList.new self
           else
-            CompositionHookContext.new(self, sid)
+              CompositionHookContext.new(self, sid)
           end
         end
 
@@ -63,11 +65,12 @@ module Twilio
         # @return [Twilio::REST::Video::V1::RecordingList]
         def recordings(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @recordings ||= RecordingList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @recordings ||= RecordingList.new self
           else
-            RecordingContext.new(self, sid)
+              RecordingContext.new(self, sid)
           end
         end
 
@@ -83,11 +86,12 @@ module Twilio
         # @return [Twilio::REST::Video::V1::RoomList]
         def rooms(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @rooms ||= RoomList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @rooms ||= RoomList.new self
           else
-            RoomContext.new(self, sid)
+              RoomContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/voice/v1.rb
+++ b/lib/twilio-ruby/rest/voice/v1.rb
@@ -29,11 +29,12 @@ module Twilio
         # @return [Twilio::REST::Voice::V1::ByocTrunkList]
         def byoc_trunks(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @byoc_trunks ||= ByocTrunkList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @byoc_trunks ||= ByocTrunkList.new self
           else
-            ByocTrunkContext.new(self, sid)
+              ByocTrunkContext.new(self, sid)
           end
         end
 
@@ -44,11 +45,12 @@ module Twilio
         # @return [Twilio::REST::Voice::V1::ConnectionPolicyList]
         def connection_policies(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @connection_policies ||= ConnectionPolicyList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @connection_policies ||= ConnectionPolicyList.new self
           else
-            ConnectionPolicyContext.new(self, sid)
+              ConnectionPolicyContext.new(self, sid)
           end
         end
 
@@ -65,11 +67,12 @@ module Twilio
         # @return [Twilio::REST::Voice::V1::IpRecordList]
         def ip_records(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @ip_records ||= IpRecordList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @ip_records ||= IpRecordList.new self
           else
-            IpRecordContext.new(self, sid)
+              IpRecordContext.new(self, sid)
           end
         end
 
@@ -80,11 +83,12 @@ module Twilio
         # @return [Twilio::REST::Voice::V1::SourceIpMappingList]
         def source_ip_mappings(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @source_ip_mappings ||= SourceIpMappingList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @source_ip_mappings ||= SourceIpMappingList.new self
           else
-            SourceIpMappingContext.new(self, sid)
+              SourceIpMappingContext.new(self, sid)
           end
         end
 

--- a/lib/twilio-ruby/rest/wireless/v1.rb
+++ b/lib/twilio-ruby/rest/wireless/v1.rb
@@ -33,11 +33,12 @@ module Twilio
         # @return [Twilio::REST::Wireless::V1::CommandList]
         def commands(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @commands ||= CommandList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @commands ||= CommandList.new self
           else
-            CommandContext.new(self, sid)
+              CommandContext.new(self, sid)
           end
         end
 
@@ -47,11 +48,12 @@ module Twilio
         # @return [Twilio::REST::Wireless::V1::RatePlanList]
         def rate_plans(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @rate_plans ||= RatePlanList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @rate_plans ||= RatePlanList.new self
           else
-            RatePlanContext.new(self, sid)
+              RatePlanContext.new(self, sid)
           end
         end
 
@@ -61,11 +63,12 @@ module Twilio
         # @return [Twilio::REST::Wireless::V1::SimList]
         def sims(sid=:unset)
           if sid.nil?
-            raise ArgumentError, 'sid cannot be nil'
-          elsif sid == :unset
-            @sims ||= SimList.new self
+              raise ArgumentError, 'sid cannot be nil'
+          end
+          if sid == :unset
+              @sims ||= SimList.new self
           else
-            SimContext.new(self, sid)
+              SimContext.new(self, sid)
           end
         end
 


### PR DESCRIPTION
# Fixes #

1. Supports date as a path parameter
2. Fixes missing parameter in the version.rb when there are >1 path parameters in the same api-def

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.


[Related PR](https://code.hq.twilio.com/twilio/yoyodyne/pull/502)