### PR TITLE
fix: Allow for capitalized attrs in autopilot keyword args

### DIFF
--- a/lib/twilio-ruby/twiml/twiml.rb
+++ b/lib/twilio-ruby/twiml/twiml.rb
@@ -29,6 +29,8 @@ module Twilio
     class TwiML
         attr_accessor :name
 
+        CAPITALIZED_KEYS = [:target_task, :memory]
+
         def initialize(**keyword_args)
           @overrides = {
               aliasAttribute: 'alias',
@@ -53,7 +55,12 @@ module Twilio
           if result.include? '_'
             result = result.split('_').map(&:capitalize).join
           end
-          result[0].downcase + result[1..result.length]
+          # fix for potentially capitalized keys
+          if CAPITALIZED_KEYS.include? symbol
+            result
+          else
+            result[0].downcase + result[1..result.length]
+          end
         end
 
         def to_s(xml_declaration = true)

--- a/spec/twiml/voice_response_spec.rb
+++ b/spec/twiml/voice_response_spec.rb
@@ -843,5 +843,22 @@ describe Twilio::TwiML::VoiceResponse do
 
       expect(parse(response)).to be_equivalent_to(expected_doc).respecting_element_order
     end
+
+    it 'should selectively capitlize some keys' do
+      expected_doc = parse <<-XML
+        <Response>
+          <Connect>
+            <Autopilot TargetTask="foobar">UAfoobar</Autopilot>
+          </Connect>
+        </Response>
+      XML
+
+      response = Twilio::TwiML::VoiceResponse.new
+      response.connect do |c|
+        c.autopilot('UAfoobar', target_task: 'foobar')
+      end
+
+      expect(parse(response)).to be_equivalent_to(expected_doc).respecting_element_order
+    end
   end
 end


### PR DESCRIPTION
Fixes #552

# Fixes #

Correctly parses autopilot keywords

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
