### PR TITLE
fix: JSON parser error on timeout response

### DIFF
--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -34,7 +34,9 @@ module Twilio
         @last_response = nil
 
         response = send(request)
-        if response.body && !response.body.empty?
+        if response.status == 504
+          object = { message: 'Request timeout', code: 504 }.to_json
+        elsif response.body && !response.body.empty?
           object = response.body
         elsif response.status == 400
           object = { message: 'Bad request', code: 400 }.to_json

--- a/spec/http/http_client_spec.rb
+++ b/spec/http/http_client_spec.rb
@@ -119,4 +119,20 @@ describe Twilio::HTTP::Client do
     expect { @client.request('host', 'port', 'GET', 'url', nil, nil, {}, ['a', 'b']) }.to raise_exception(Twilio::REST::TwilioError)
     expect(@client.last_response).to be_nil
   end
+
+  context 'when the response returns a timeout' do
+    let(:twilio_response) { @client.request('host', 'port', 'GET', 'url') }
+
+    before do
+      faraday_connection = Faraday::Connection.new
+
+      allow(Faraday).to receive(:new).and_return(faraday_connection)
+      allow(faraday_connection).to receive(:send).and_return(double('response', status: 504, body: { message: 'any message' }, headers: {}))
+    end
+
+    it 'adds a Request timeout message to the response and avoids non-JSON response to raise Json::ParserError' do
+      expect(twilio_response.body).to eq({ 'message' => 'Request timeout', 'code' => 504 })
+      expect(twilio_response.status_code).to eq 504
+    end
+  end
 end


### PR DESCRIPTION
This PR aims to fix the JSON::ParserError (reported on issue #544) when the client returns a
timeout response by skipping parsing the response body when the response
status code is 504.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

A short description of what this PR does.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
