### PR TITLE
Fix: Adds to_json to response objects that inherit from Domain.

### DIFF
--- a/lib/twilio-ruby/framework/domain.rb
+++ b/lib/twilio-ruby/framework/domain.rb
@@ -31,6 +31,10 @@ module Twilio
           timeout
         )
       end
+
+      def as_json(*)
+        @properties
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #555 
Fixes #423

Prevents a stack level too deep error when `to_json` is called on a response object.

I did not add tests because the issue cannot be replicated at the gem level. However if you would like a test to prove it doesn't break anything I would be happy to include it.

There was no other documentation in the `Domain` class and since `to_json` and `as_json` are fairly well known I didn't think it was necessary to add any.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x ] I have titled the PR appropriately
- [x ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
