### PR TITLE
Fix: deprecation warning on Faraday

### DIFF
--- a/lib/twilio-ruby/http/http_client.rb
+++ b/lib/twilio-ruby/http/http_client.rb
@@ -31,7 +31,7 @@ module Twilio
           f.options.params_encoder = Faraday::FlatParamsEncoder
           f.request :url_encoded
           f.headers = request.headers
-          f.basic_auth(request.auth[0], request.auth[1])
+          f.request(:basic_auth, request.auth[0], request.auth[1])
           f.proxy = "#{@proxy_prot}://#{@proxy_auth}#{@proxy_path}" if @proxy_prot && @proxy_path
           f.options.open_timeout = request.timeout || @timeout
           f.options.timeout = request.timeout || @timeout


### PR DESCRIPTION
warning:
> WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
> While initializing your connection, use `#request(:basic_auth, ...)` instead.
> See https://lostisland.github.io/faraday/middleware/authentication for more usage info.

![image](https://user-images.githubusercontent.com/12391171/131395837-4c47fb7a-7cba-4159-a1a5-3b7a8b3bcfbb.png)

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the Contribution Guidelines and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified