### PR TITLE
fix: fix travis build for ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: focal
 cache: bundler
 bundler_args: "--without development"
 rvm:


### PR DESCRIPTION
Switch the `dist` to `focal` to download rvm installer on version 3.0.0. 
Github issue here: https://github.com/rvm/rvm/issues/5133