### PR TITLE
fix: issue 560 - missing ancestor for Autopilot

### DIFF
--- a/lib/twilio-ruby/rest/autopilot/v1.rb
+++ b/lib/twilio-ruby/rest/autopilot/v1.rb
@@ -8,7 +8,7 @@
 
 module Twilio
   module REST
-    class Autopilot
+    class Autopilot < Domain
       class V1 < Version
         ##
         # Initialize the V1 version of Autopilot


### PR DESCRIPTION

Fixes #560

All throughout the v1 namespace Autopilot class inherites from Domain class. It should inherit from it everywhere or a
conflict of ancestors will happen.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
