### PR TITLE
chore: make ruby-head test optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7, '3.0', ruby-head, jruby-9.2]
+    continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
     steps:
       - name: Checkout twilio-ruby
         uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.4
   Exclude:
     - 'lib/twilio-ruby/rest/**/*'
     - 'spec/integration/**/*'

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test: lint
 	bundle exec rake spec
 
 lint:
-	bundle exec rubocop --cache true --parallel
+	bundle exec rubocop -d --cache true --parallel
 
 docs:
 	yard doc --output-dir ./doc

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.83.0'
+  spec.add_development_dependency 'rubocop', '~> 0.82.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
   spec.add_development_dependency 'logger', '~> 1.4.2'
 end

--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.82.0'
+  spec.add_development_dependency 'rubocop', '~> 0.83.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
   spec.add_development_dependency 'logger', '~> 1.4.2'
 end


### PR DESCRIPTION
Rubocop linting fails on `ruby-head` tests (aka ruby `v3.1.0`). Response from [rubocop team](https://github.com/rubocop/rubocop/issues/10258) is to upgrade from rubocop `0.82.0` to `v1.22.3`. We cannot do this until we drop support for ruby v2.4 in this helper. This PR allows test workflows to run and pass with success even if the single ruby-head test fails. 