### PR TITLE
fix: Validate signatures in Rack middleware for non-form-data payloads

### DIFF
--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rack/media_type'
 
 module Rack
@@ -53,8 +54,8 @@ module Rack
     # Extract the params from the the request that we can use to determine the
     # signature. This _may_ modify the passed in request since it may read/rewind
     # the body.
-    private def extract_params!(request)
-      return {} if !request.post?
+    def extract_params!(request)
+      return {} unless request.post?
 
       if request.media_type == FORM_URLENCODED_MEDIA_TYPE
         request.POST
@@ -65,5 +66,7 @@ module Rack
         body
       end
     end
+
+    private :extract_params!
   end
 end

--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -56,8 +56,7 @@ module Rack
     private def extract_params!(request)
       return {} if !request.post?
 
-      case request.media_type
-      when FORM_URLENCODED_MEDIA_TYPE
+      if request.media_type == FORM_URLENCODED_MEDIA_TYPE
         request.POST
       else
         request.body.rewind

--- a/spec/rack/twilio_webhook_authentication_spec.rb
+++ b/spec/rack/twilio_webhook_authentication_spec.rb
@@ -31,6 +31,7 @@ describe Rack::TwilioWebhookAuthentication do
       auth_token = 'qwerty'
       account_sid = 12_345
       expect_any_instance_of(Rack::Request).to receive(:post?).and_return(true)
+      expect_any_instance_of(Rack::Request).to receive(:media_type).and_return(Rack::MediaType.type('application/x-www-form-urlencoded'))
       expect_any_instance_of(Rack::Request).to receive(:POST).and_return({ 'AccountSid' => account_sid })
       @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/) { |asid| auth_token }
       request_validator = double('RequestValidator')
@@ -101,6 +102,94 @@ describe Rack::TwilioWebhookAuthentication do
       request = Rack::MockRequest.env_for('/sms')
       status, headers, body = @middleware.call(request)
       expect(status).to be(403)
+    end
+  end
+
+  describe 'validating non-form-data POST payloads' do
+    it 'should fail if the body does not validate' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, 'qwerty', /\/test/)
+      input = StringIO.new('{"message": "a post body that does not match the bodySHA256"}')
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test?bodySHA256=79bfb0acaf0045fd30f13d48d4fe296b393d85a3bfbee881a0172b2bd574b11e',
+        method: 'POST',
+        input: input
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = '+LYlbGr/VmN84YPJQCuWs+9UA7E='
+      request['CONTENT_TYPE'] = 'application/json'
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).not_to be(200)
+    end
+
+    it 'should validate if the body signature is correct' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, 'qwerty', /\/test/)
+      input = StringIO.new('{"message": "a post body"}')
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test?bodySHA256=8d90d640c6ba47d595ac56203d7f5c6b511be80fdf44a2055acca75a119b9fd2',
+        method: 'POST',
+        input: input
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = 'zR5Oq4f6cijN5oz5bisiVuxYnTU='
+      request['CONTENT_TYPE'] = 'application/json'
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).to be(200)
+    end
+
+    it 'should validate even if a previous middleware read the body first' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, 'qwerty', /\/test/)
+      input = StringIO.new('{"message": "a post body"}')
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test?bodySHA256=8d90d640c6ba47d595ac56203d7f5c6b511be80fdf44a2055acca75a119b9fd2',
+        method: 'POST',
+        input: input
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = 'zR5Oq4f6cijN5oz5bisiVuxYnTU='
+      request['CONTENT_TYPE'] = 'application/json'
+      request['rack.input'].read
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).to be(200)
+    end
+  end
+
+  describe 'validating application/x-www-form-urlencoded POST payloads' do
+    it 'should fail if the body does not validate' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, 'qwerty', /\/test/)
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test',
+        method: 'POST',
+        params: {'foo' => 'bar'}
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = 'foobarbaz'
+      expect(request['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).not_to be(200)
+    end
+
+    it 'should validate if the body signature is correct' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, 'qwerty', /\/test/)
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test',
+        method: 'POST',
+        params: {'foo' => 'bar'}
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = 'TR9Skm9jiF4WVRJznU5glK5I83k='
+      expect(request['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).to be(200)
     end
   end
 end

--- a/spec/rack/twilio_webhook_authentication_spec.rb
+++ b/spec/rack/twilio_webhook_authentication_spec.rb
@@ -166,7 +166,7 @@ describe Rack::TwilioWebhookAuthentication do
       request = Rack::MockRequest.env_for(
         'https://example.com/test',
         method: 'POST',
-        params: {'foo' => 'bar'}
+        params: { 'foo' => 'bar' }
       )
       request['HTTP_X_TWILIO_SIGNATURE'] = 'foobarbaz'
       expect(request['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')
@@ -182,7 +182,7 @@ describe Rack::TwilioWebhookAuthentication do
       request = Rack::MockRequest.env_for(
         'https://example.com/test',
         method: 'POST',
-        params: {'foo' => 'bar'}
+        params: { 'foo' => 'bar' }
       )
       request['HTTP_X_TWILIO_SIGNATURE'] = 'TR9Skm9jiF4WVRJznU5glK5I83k='
       expect(request['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')


### PR DESCRIPTION
The webhook authentication middleware has been using the return value of `request.POST` to determine the params to validate, assuming it returns a non-`Hash` in the case of a non-formish-POST. However, this is not true, though perhaps it was at some point in the past:

https://github.com/rack/rack/blob/8c9a97fe6073a8f4c17f85fff20f20eae22d1bcb/lib/rack/request.rb#L451-L478

This means the `RequestValidator` body validation code is entirely skipped over, since `params_hash` is always `Enumerable`:

https://github.com/twilio/twilio-ruby/blob/6c50e0fa13bfefdcdaaa0799b8798023ce492e60/lib/twilio-ruby/security/request_validator.rb#L34-L39

So the body is always considered valid, and only the URL signature is ever validated:

https://github.com/twilio/twilio-ruby/blob/6c50e0fa13bfefdcdaaa0799b8798023ce492e60/lib/twilio-ruby/security/request_validator.rb#L32
https://github.com/twilio/twilio-ruby/blob/6c50e0fa13bfefdcdaaa0799b8798023ce492e60/lib/twilio-ruby/security/request_validator.rb#L46

This fixes the problem by being strict about what's considered a form, and actually reading the body as the params in the case the middleware has not received a form.

I don't actually know how Twilio calculates signatures for `multipart/form-data` requests, if it ever makes them at all, so these aren't treated any differently than any other non `application/x-www-form-urlencoded` body.

----

### Proof of Concept

[`gabrielg/twilio-ruby-signature-issue`](https://github.com/gabrielg/twilio-ruby-signature-issue) is a Sinatra app I prepared earlier. `main` has the broken code, `fixed` vendors this branch.

I needed a JSON payload, so I set up an Event Streams sink and subscription and sent a message to a number. Here's what that looks like, with the `from` and `to` numbers redacted for privacy:

```
2022-01-20T04:21:12.848949+00:00 app[web.1]: I, [2022-01-20T04:21:12.848877 #4]  INFO -- : Request signature: Z8VaIO3lzXlpt4Wo2+1cLewPNHc=
2022-01-20T04:21:12.848971+00:00 app[web.1]: I, [2022-01-20T04:21:12.848949 #4]  INFO -- : Request body: "[{\"specversion\":\"1.0\",\"type\":\"com.twilio.messaging.inbound-message.received\",\"source\":\"/2010-04-01/Accounts/ACd19cd7a2e1dd2459a0134a1045a8ad22/Messages/SMb7f53fae9b4e2f7934db56a85dc380a6.json\",\"id\":\"EZ0b589f28245712b627d6281e12452ca4\",\"dataschema\":\"https://events-schemas.twilio.com/Messaging.InboundMessageV1/1\",\"datacontenttype\":\"application/json\",\"time\":\"2022-01-20T04:21:12.000Z\",\"data\":{\"fromState\":\"IL\",\"eventName\":\"com.twilio.messaging.inbound-message.received\",\"body\":\"test \",\"numMedia\":0,\"toZip\":\"35160\",\"timestamp\":\"2022-01-20T04:21:12.000Z\",\"fromCity\":\"CHICAGO\",\"accountSid\":\"ACd19cd7a2e1dd2459a0134a1045a8ad22\",\"to\":\"+[REDACTED]\",\"toCountry\":\"TALLADEGA\",\"toState\":\"AL\",\"toCity\":\"TALLADEGA\",\"from\":\"+[REDACTED]\",\"fromCountry\":\"US\",\"numSegments\":1,\"messageSid\":\"SMb7f53fae9b4e2f7934db56a85dc380a6\",\"fromZip\":\"60603\"}}]"
2022-01-20T04:21:12.849007+00:00 app[web.1]: I, [2022-01-20T04:21:12.848985 #4]  INFO -- : Request URL: https://twilio-ruby-poc.herokuapp.com/incoming?bodySHA256=afa6016db35c4065e97fcbbd50263823ab6a02a8041b406876c5ac87078ced90
2022-01-20T04:21:12.849023+00:00 app[web.1]: I, [2022-01-20T04:21:12.849005 #4]  INFO -- : Request media type: application/json
2022-01-20T04:21:12.849165+00:00 app[web.1]: 54.234.178.255 - - [20/Jan/2022:04:21:12 +0000] "POST /incoming?bodySHA256=afa6016db35c4065e97fcbbd50263823ab6a02a8041b406876c5ac87078ced90 HTTP/1.1" 200 31 0.0008
```

I can take that signature and URL, set the `Content-Type` to `application/json`, and `curl` anything and have it pass signature validation:

```
$ curl -X POST -H "X-Twilio-Signature: Z8VaIO3lzXlpt4Wo2+1cLewPNHc=" -H "Content-Type: application/json" -d "does not matter" https://twilio-ruby-poc.herokuapp.com/incoming\?bodySHA256\=afa6016db35c4065e97fcbbd50263823ab6a02a8041b406876c5ac87078ced90
Signature validation succeeded.
```

A bad actor thus only needs a valid signature and URL to make requests, not the original auth token used for signing.

I also set up another sink and subscription against a Heroku app running the `fixed` branch. An incoming message against it looks like:

```
2022-01-20T04:21:12.851310+00:00 app[web.1]: I, [2022-01-20T04:21:12.851254 #4]  INFO -- : Request signature: 17BMAnL0duOg0piNC/D2Xx5BWiE=
2022-01-20T04:21:12.851341+00:00 app[web.1]: I, [2022-01-20T04:21:12.851316 #4]  INFO -- : Request body: "[{\"specversion\":\"1.0\",\"type\":\"com.twilio.messaging.inbound-message.received\",\"source\":\"/2010-04-01/Accounts/ACd19cd7a2e1dd2459a0134a1045a8ad22/Messages/SMb7f53fae9b4e2f7934db56a85dc380a6.json\",\"id\":\"EZ0b589f28245712b627d6281e12452ca4\",\"dataschema\":\"https://events-schemas.twilio.com/Messaging.InboundMessageV1/1\",\"datacontenttype\":\"application/json\",\"time\":\"2022-01-20T04:21:12.000Z\",\"data\":{\"fromState\":\"IL\",\"eventName\":\"com.twilio.messaging.inbound-message.received\",\"body\":\"test \",\"numMedia\":0,\"toZip\":\"35160\",\"timestamp\":\"2022-01-20T04:21:12.000Z\",\"fromCity\":\"CHICAGO\",\"accountSid\":\"ACd19cd7a2e1dd2459a0134a1045a8ad22\",\"to\":\"+[REDACTED]\",\"toCountry\":\"TALLADEGA\",\"toState\":\"AL\",\"toCity\":\"TALLADEGA\",\"from\":\"+[REDACTED]\",\"fromCountry\":\"US\",\"numSegments\":1,\"messageSid\":\"SMb7f53fae9b4e2f7934db56a85dc380a6\",\"fromZip\":\"60603\"}}]"
2022-01-20T04:21:12.851410+00:00 app[web.1]: I, [2022-01-20T04:21:12.851386 #4]  INFO -- : Request URL: https://obscure-citadel-66169.herokuapp.com/incoming?bodySHA256=afa6016db35c4065e97fcbbd50263823ab6a02a8041b406876c5ac87078ced90
2022-01-20T04:21:12.851431+00:00 app[web.1]: I, [2022-01-20T04:21:12.851413 #4]  INFO -- : Request media type: application/json
2022-01-20T04:21:12.851616+00:00 app[web.1]: 54.172.192.162 - - [20/Jan/2022:04:21:12 +0000] "POST /incoming?bodySHA256=afa6016db35c4065e97fcbbd50263823ab6a02a8041b406876c5ac87078ced90 HTTP/1.1" 200 31 0.0009
```

If I take that signature and URL and attempt to tamper with the body, validation now fails, as expected:

```
curl -X POST -H "X-Twilio-Signature: 17BMAnL0duOg0piNC/D2Xx5BWiE=" -H "Content-Type: application/json" -d "does not matter" https://obscure-citadel-66169.herokuapp.com/incoming\?bodySHA256\=afa6016db35c4065e97fcbbd50263823ab6a02a8041b406876c5ac87078ced90
Twilio Request Validation Failed.
```

----

FWIW: I tried to disclose this problem and the fix via Bugcrowd but was told that non-validation of webhook signatures is not, in fact, considered a security issue.

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
