### PR TITLE
fix: Promote rack to runtime dependency because of 5.63.1

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency('jwt', '>= 1.5', '<= 2.5')
   spec.add_dependency('nokogiri', '>= 1.6', '< 2.0')
   spec.add_dependency('faraday', '>= 0.9', '< 2.0')
+  spec.add_dependency('rack', '~> 2.0')
   # Workaround for RBX <= 2.2.1, should be fixed in next version
   spec.add_dependency('rubysl') if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 
   spec.add_development_dependency 'bundler', '>= 1.5', '< 3.0'
   spec.add_development_dependency 'equivalent-xml', '~> 0.6'
   spec.add_development_dependency 'fakeweb', '~> 1.3'
-  spec.add_development_dependency 'rack', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'


### PR DESCRIPTION
Fixes #592

5.63.1 (specifically 9d69b6ef78c93e43e73e968685e3cd44342bd537)  introduced a reliance on `rack/media_type` which was previously only a development dependency of this gem. 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
