### PR TITLE
fix: move require into TwilioWebhookAuthentication initialize (Fixes twilio/twilio-ruby#592)

### DIFF
--- a/lib/rack/twilio_webhook_authentication.rb
+++ b/lib/rack/twilio_webhook_authentication.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rack/media_type'
-
 module Rack
   # Middleware that authenticates webhooks from Twilio using the request
   # validator.
@@ -23,9 +21,9 @@ module Rack
   class TwilioWebhookAuthentication
     # Rack's FORM_DATA_MEDIA_TYPES can be modified to taste, so we're slightly
     # more conservative in what we consider form data.
-    FORM_URLENCODED_MEDIA_TYPE = Rack::MediaType.type('application/x-www-form-urlencoded')
-
     def initialize(app, auth_token, *paths, &auth_token_lookup)
+      require 'rack/media_type'
+
       @app = app
       @auth_token = auth_token
       define_singleton_method(:get_auth_token, auth_token_lookup) if block_given?
@@ -57,7 +55,7 @@ module Rack
     def extract_params!(request)
       return {} unless request.post?
 
-      if request.media_type == FORM_URLENCODED_MEDIA_TYPE
+      if request.media_type == Rack::MediaType.type('application/x-www-form-urlencoded')
         request.POST
       else
         request.body.rewind


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Fixes #592

I have moved the `require` into the `initialize` so it is only executed if the user needs the functionality. This is an alternative fix to just requiring the rack gem in the gemspec.

I have run the existing tests and my own tests that were failing in 5.63.1 due to the issue.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
