### PR TITLE
feat!: Add secondary token support to Rack::TwilioWebhookAuthentication

### DIFF
--- a/lib/twilio-ruby/security/request_validator.rb
+++ b/lib/twilio-ruby/security/request_validator.rb
@@ -38,6 +38,8 @@ module Twilio
           params_hash = {}
         end
 
+        return false unless valid_body
+
         # Check signature of the url with and without port numbers
         # since signature generation on the back end is inconsistent
         valid_signature_with_port = secure_compare(build_signature_for(url_with_port, params_hash), signature)

--- a/spec/rack/twilio_webhook_authentication_spec.rb
+++ b/spec/rack/twilio_webhook_authentication_spec.rb
@@ -24,19 +24,26 @@ describe Rack::TwilioWebhookAuthentication do
         Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/, /\/sms/)
       end.not_to raise_error
     end
+
+    it 'should initialize with an app, auth token(s) and a path' do
+      expect do
+        Rack::TwilioWebhookAuthentication.new(@app, ['ABC', 'DEF'], /\/voice/, /\/sms/)
+      end.not_to raise_error
+    end
   end
 
   describe 'calling against one path with dynamic auth token' do
+    before do
+      allow_any_instance_of(Rack::Request).to receive(:post?).and_return(true)
+      allow_any_instance_of(Rack::Request).to receive(:media_type).and_return(Rack::MediaType.type('application/x-www-form-urlencoded'))
+      allow_any_instance_of(Rack::Request).to receive(:POST).and_return({ 'AccountSid' => 12_345 })
+
+      @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/) { |asid| 'qwerty' }
+    end
+
     it 'should allow a request through if it validates' do
-      auth_token = 'qwerty'
-      account_sid = 12_345
-      expect_any_instance_of(Rack::Request).to receive(:post?).and_return(true)
-      expect_any_instance_of(Rack::Request).to receive(:media_type).and_return(Rack::MediaType.type('application/x-www-form-urlencoded'))
-      expect_any_instance_of(Rack::Request).to receive(:POST).and_return({ 'AccountSid' => account_sid })
-      @middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/voice/) { |asid| auth_token }
-      request_validator = double('RequestValidator')
-      expect(Twilio::Security::RequestValidator).to receive(:new).with(auth_token).and_return(request_validator)
-      expect(request_validator).to receive(:validate).and_return(true)
+      allow_any_instance_of(Twilio::Security::RequestValidator).to receive(:validate).and_return(true)
+
       request = Rack::MockRequest.env_for('/voice')
       status, headers, body = @middleware.call(request)
       expect(status).to be(200)
@@ -71,6 +78,35 @@ describe Rack::TwilioWebhookAuthentication do
       request = Rack::MockRequest.env_for('/voice')
       status, headers, body = @middleware.call(request)
       expect(status).to be(403)
+    end
+
+    context 'with secondary auth_token' do
+      let(:auth_token) { ['ABC', 'DEF'] }
+
+      it 'should not intercept when the path doesn\'t match' do
+        expect(Twilio::Security::RequestValidator).to_not receive(:validate)
+        request = Rack::MockRequest.env_for('/sms')
+        status, headers, body = @middleware.call(request)
+        expect(status).to be(200)
+      end
+
+      it 'should allow a request through if it validates' do
+        expect_any_instance_of(Twilio::Security::RequestValidator).to(
+          receive(:validate).and_return(true)
+        )
+        request = Rack::MockRequest.env_for('/voice')
+        status, headers, body = @middleware.call(request)
+        expect(status).to be(200)
+      end
+
+      it 'should short circuit a request to 403 if it does not validate' do
+        expect_any_instance_of(Twilio::Security::RequestValidator).to(
+          receive(:validate).and_return(false)
+        )
+        request = Rack::MockRequest.env_for('/voice')
+        status, headers, body = @middleware.call(request)
+        expect(status).to be(403)
+      end
     end
   end
 
@@ -125,6 +161,59 @@ describe Rack::TwilioWebhookAuthentication do
 
     it 'should validate if the body signature is correct' do
       middleware = Rack::TwilioWebhookAuthentication.new(@app, 'qwerty', /\/test/)
+      input = StringIO.new('{"message": "a post body"}')
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test?bodySHA256=8d90d640c6ba47d595ac56203d7f5c6b511be80fdf44a2055acca75a119b9fd2',
+        method: 'POST',
+        input: input
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = 'zR5Oq4f6cijN5oz5bisiVuxYnTU='
+      request['CONTENT_TYPE'] = 'application/json'
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).to be(200)
+    end
+
+    it 'should validate if the body signature is correct for secondary token' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, ['invalid', 'qwerty'], /\/test/)
+      input = StringIO.new('{"message": "a post body"}')
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test?bodySHA256=8d90d640c6ba47d595ac56203d7f5c6b511be80fdf44a2055acca75a119b9fd2',
+        method: 'POST',
+        input: input
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = 'zR5Oq4f6cijN5oz5bisiVuxYnTU='
+      request['CONTENT_TYPE'] = 'application/json'
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).to be(200)
+    end
+
+    it 'should fail if the body does not validate for any token' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, ['invalid', 'invalid2', 'invalid3'], /\/test/)
+      input = StringIO.new('{"message": "a post body that does not match the bodySHA256"}')
+
+      request = Rack::MockRequest.env_for(
+        'https://example.com/test?bodySHA256=79bfb0acaf0045fd30f13d48d4fe296b393d85a3bfbee881a0172b2bd574b11e',
+        method: 'POST',
+        input: input
+      )
+      request['HTTP_X_TWILIO_SIGNATURE'] = '+LYlbGr/VmN84YPJQCuWs+9UA7E='
+      request['CONTENT_TYPE'] = 'application/json'
+
+      status, headers, body = middleware.call(request)
+
+      expect(status).not_to be(200)
+    end
+
+    it 'should validate if the body signature is correct for dynamic secondary token' do
+      middleware = Rack::TwilioWebhookAuthentication.new(@app, nil, /\/test/) do |account_sid|
+        return ['invalid', 'qwerty']
+      end
       input = StringIO.new('{"message": "a post body"}')
 
       request = Rack::MockRequest.env_for(


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

# Fixes #

Add support for multiple auth tokens to `Rack::TwilioWebhookAuthentication` middleware.  The goal of having multiple tokens is to support [Secondary Auth Tokens](https://www.twilio.com/blog/2014/12/introducing-secondary-auth-tokens-nt.html)

A short description of what this PR does.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
