### PR TITLE
fix: don't load webhook authentication if Rack not present

### DIFF
--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -10,7 +10,7 @@ require 'time'
 require 'json'
 
 require 'twilio-ruby/version' unless defined?(Twilio::VERSION)
-require 'rack/twilio_webhook_authentication'
+require 'rack/twilio_webhook_authentication' if defined?(Rack)
 
 require 'twilio-ruby/util'
 require 'twilio-ruby/security/request_validator'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,8 @@ Dir.glob(File.expand_path('../support/**/*.rb', __FILE__)).sort.each(&method(:re
 require_relative './holodeck/holodeck.rb'
 require_relative './holodeck/hologram.rb'
 
-require 'twilio-ruby'
 require 'rack'
+require 'twilio-ruby'
 require 'rspec/matchers'
 require 'equivalent-xml'
 


### PR DESCRIPTION
Now that the webhook authentication requires part of Rack to run, loading the gem in a context that doesn't include Rack fails. For most people this won't happen as it will be used in the context of a web framework and most Ruby web frameworks rely on Rack. However, simple scripts that don't have Rack loaded will fail because the application can't load rack/media_type. In these cases, since Rack is not present, rack middleware won't be helpful either, so we only load the Rack middleware if Rack is present.


# Fixes #

A short description of what this PR does.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
