### PR TITLE
fix: Only require twilio_webhook_authentication if Rack version > 2

### DIFF
--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -10,7 +10,7 @@ require 'time'
 require 'json'
 
 require 'twilio-ruby/version' unless defined?(Twilio::VERSION)
-require 'rack/twilio_webhook_authentication' if defined?(Rack) && (Gem.loaded_specs["rack"].version > Gem::Version.new("2"))
+require 'rack/twilio_webhook_authentication' if defined?(Rack) && defined?(Rack::MediaType)
 
 require 'twilio-ruby/util'
 require 'twilio-ruby/security/request_validator'

--- a/lib/twilio-ruby.rb
+++ b/lib/twilio-ruby.rb
@@ -10,7 +10,7 @@ require 'time'
 require 'json'
 
 require 'twilio-ruby/version' unless defined?(Twilio::VERSION)
-require 'rack/twilio_webhook_authentication' if defined?(Rack)
+require 'rack/twilio_webhook_authentication' if defined?(Rack) && (Gem.loaded_specs["rack"].version > Gem::Version.new("2"))
 
 require 'twilio-ruby/util'
 require 'twilio-ruby/security/request_validator'


### PR DESCRIPTION
Fixes #605 

# Fixes #

Only require the twilio_webhook_authentication functionality if the Rack version is > 2.

FYI, #602 attempted to fix this, but doesn't work when the Rack version is < 2.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
