### PR TITLE
fix: Retrieval of OS Info with Ruby Config for User Agent string

### DIFF
--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -70,7 +70,8 @@ module Twilio
       def request(host, port, method, uri, params={}, data={}, headers={}, auth=nil, timeout=nil)
         auth ||= @auth
 
-        headers['User-Agent'] = "twilio-ruby/#{Twilio::VERSION} (#{`uname -s`.chomp} #{`uname -m`.chomp}) Ruby/#{RUBY_VERSION}"
+        ruby_config = RbConfig::CONFIG
+        headers['User-Agent'] = "twilio-ruby/#{Twilio::VERSION} (#{ruby_config["host_os"]} #{ruby_config["host_cpu"]}) Ruby/#{RUBY_VERSION}"
         headers['Accept-Charset'] = 'utf-8'
 
         user_agent_extensions.each { |extension| headers['User-Agent'] += " #{extension}" }

--- a/lib/twilio-ruby/rest/client.rb
+++ b/lib/twilio-ruby/rest/client.rb
@@ -13,11 +13,11 @@ module Twilio
     class Client
       @@default_region = 'us1'
 
-      attr_accessor :http_client, :username, :password, :account_sid, :auth_token, :region, :edge, :logger
+      attr_accessor :http_client, :username, :password, :account_sid, :auth_token, :region, :edge, :logger, :user_agent_extensions
 
       ##
       # Initializes the Twilio Client
-      def initialize(username=nil, password=nil, account_sid=nil, region=nil, http_client=nil, logger=nil)
+      def initialize(username=nil, password=nil, account_sid=nil, region=nil, http_client=nil, logger=nil, user_agent_extensions=nil)
         @username = username || Twilio.account_sid
         @password = password || Twilio.auth_token
         @region = region || Twilio.region
@@ -27,6 +27,7 @@ module Twilio
         @auth = [@username, @password]
         @http_client = http_client || Twilio.http_client || Twilio::HTTP::Client.new
         @logger = logger || Twilio.logger
+        @user_agent_extensions = user_agent_extensions || []
 
         # Domains
         @accounts = nil
@@ -69,10 +70,10 @@ module Twilio
       def request(host, port, method, uri, params={}, data={}, headers={}, auth=nil, timeout=nil)
         auth ||= @auth
 
-        headers['User-Agent'] = "twilio-ruby/#{Twilio::VERSION}" +
-                                " (#{RUBY_ENGINE}/#{RUBY_PLATFORM}" +
-                                " #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL})"
+        headers['User-Agent'] = "twilio-ruby/#{Twilio::VERSION} (#{`uname -s`.chomp} #{`uname -m`.chomp}) Ruby/#{RUBY_VERSION}"
         headers['Accept-Charset'] = 'utf-8'
+
+        user_agent_extensions.each { |extension| headers['User-Agent'] += " #{extension}" }
 
         if method == 'POST' && !headers['Content-Type']
           headers['Content-Type'] = 'application/x-www-form-urlencoded'

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -263,7 +263,7 @@ describe Twilio::REST::Client do
 
     it 'use default user agent format' do
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
-      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{^twilio-ruby/[0-9.]+\s\([\w+-]\s\w+\)\sRuby/[^\s]+$}
+      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{^twilio-ruby/[0-9.]+\s\([\w-]+\s\w+\)\sRuby/[^\s]+$}
     end
 
     it 'add user agent extensions' do

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -263,11 +263,11 @@ describe Twilio::REST::Client do
 
     it 'use default user agent format' do
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
-      expect(@client.http_client.last_request.headers['User-Agent']).to match(/^twilio-ruby\/[0-9.]+\s\(\w+\s\w+\)\sRuby\/[^\s]+$/)
+      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{/^twilio-ruby\/[0-9.]+\s\(\w+\s\w+\)\sRuby\/[^\s]+$/}
     end
 
     it 'add user agent extensions' do
-      extensions = %w(twilio-run/2.0.0-test flex-plugin/3.4.0)
+      extensions = ['twilio-run/2.0.0-test', 'flex-plugin/3.4.0']
       @client.user_agent_extensions = extensions
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
       actual_extensions = @client.http_client.last_request.headers['User-Agent'].split(/ /).last(extensions.size)

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -263,7 +263,7 @@ describe Twilio::REST::Client do
 
     it 'use default user agent format' do
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
-      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{/^twilio-ruby\/[0-9.]+\s\(\w+\s\w+\)\sRuby\/[^\s]+$/}
+      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{^twilio-ruby/[0-9.]+\s\(\w+\s\w+\)\sRuby/[^\s]+$}
     end
 
     it 'add user agent extensions' do

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -268,7 +268,7 @@ describe Twilio::REST::Client do
 
     it 'add user agent extensions' do
       extensions = ['twilio-run/2.0.0-test', 'flex-plugin/3.4.0']
-      @client.user_agent_extensions = extensionsgit 
+      @client.user_agent_extensions = extensions
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
       actual_extensions = @client.http_client.last_request.headers['User-Agent'].split(/ /).last(extensions.size)
       expect(actual_extensions).to match_array(extensions)

--- a/spec/rest/client_spec.rb
+++ b/spec/rest/client_spec.rb
@@ -263,12 +263,12 @@ describe Twilio::REST::Client do
 
     it 'use default user agent format' do
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
-      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{^twilio-ruby/[0-9.]+\s\(\w+\s\w+\)\sRuby/[^\s]+$}
+      expect(@client.http_client.last_request.headers['User-Agent']).to match %r{^twilio-ruby/[0-9.]+\s\([\w+-]\s\w+\)\sRuby/[^\s]+$}
     end
 
     it 'add user agent extensions' do
       extensions = ['twilio-run/2.0.0-test', 'flex-plugin/3.4.0']
-      @client.user_agent_extensions = extensions
+      @client.user_agent_extensions = extensionsgit 
       @client.request('host', 'port', 'GET', 'https://api.twilio.com')
       actual_extensions = @client.http_client.last_request.headers['User-Agent'].split(/ /).last(extensions.size)
       expect(actual_extensions).to match_array(extensions)


### PR DESCRIPTION
Modify retrieval of os name and arch with Ruby Config instead of linux commands

https://github.com/twilio/twilio-ruby/pull/604#issuecomment-1114624543
