### PR TITLE
fix: Make RequestValidator#validate fail if URL has no query params

### DIFF
--- a/lib/twilio-ruby/security/request_validator.rb
+++ b/lib/twilio-ruby/security/request_validator.rb
@@ -32,7 +32,7 @@ module Twilio
         valid_body = true # default succeed, since body not always provided
         params_hash = body_or_hash(params)
         unless params_hash.is_a? Enumerable
-          body_hash = URI.decode_www_form(parsed_url.query).to_h['bodySHA256']
+          body_hash = URI.decode_www_form(parsed_url.query || '').to_h['bodySHA256']
           params_hash = build_hash_for(params)
           valid_body = !(params_hash.nil? || body_hash.nil?) && secure_compare(params_hash, body_hash)
           params_hash = {}

--- a/spec/security/request_validator_spec.rb
+++ b/spec/security/request_validator_spec.rb
@@ -81,6 +81,11 @@ describe Twilio::Security::RequestValidator do
       expect(validator.validate(url, body, default_signature)).to eq(false)
     end
 
+    it 'should fail validation with body but no query parameters' do
+      url_without_params = url.split('?').first
+      expect(validator.validate(url_without_params, body, default_signature)).to eq(false)
+    end
+
     it 'should validate https urls with ports by stripping them' do
       url_with_port = url.sub('.com', '.com:1234')
       expect(validator.validate(url_with_port, params, default_signature)).to eq(true)


### PR DESCRIPTION
Fixes #613 

I ran into this issue when I wrongly expected JSON requests I am making from a Twilio serverless function to one of my services to be correctly verified. I know that Twilio will always include the `bodySHA256` query parameter for JSON requests. But if you use `Twilio::Security::RequestValidator#validate` in a custom way you might pass the wrong URL and in that case it shouldn't crash.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
