### PR TITLE
chore: Bump jwt version max version to 2.6

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['README.md', 'LICENSE']
   spec.rdoc_options = ['--line-numbers', '--inline-source', '--title', 'twilio-ruby', '--main', 'README.md']
 
-  spec.add_dependency('jwt', '>= 1.5', '<= 2.5')
+  spec.add_dependency('jwt', '>= 1.5', '<= 2.6')
   spec.add_dependency('nokogiri', '>= 1.6', '< 2.0')
   spec.add_dependency('faraday', '>= 0.9', '< 3.0')
   # Workaround for RBX <= 2.2.1, should be fixed in next version


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #625 
-->

# Fixes #

Closes #625 by increasing the maximum allowed version of the [ruby-jwt gem](https://github.com/jwt/ruby-jwt) to be 2.6.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
