### PR TITLE
chore: `bundle install` with `--with` option is dispensable in this case

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         run: bundle add rubocop --version "~> 1.24.1" --group "development" --skip-install
         if: ${{ matrix.ruby != '2.4' }}
 
-      - run: bundle install --with development
+      - run: bundle install
       - run: bundle exec rake install
 
       - name: Run linter

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'simplecov', require: false, group: :test
+gem 'simplecov', require: false
 gemspec

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ githooks:
 	ln -sf ../../githooks/pre-commit .git/hooks/pre-commit
 
 install:
-	bundle install --with development; bundle exec rake install
+	bundle install; bundle exec rake install
 
 test:
 	bundle exec rake spec


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

TLDR; `bundle install` and `bundle install --with development` both install the same set. So perhaps one without flag is clearer to use?

The setup script and the ci workflow definition specify that bundler should use `--with development` option, which has been deprecated as of newer version of bundler. Mine is 2.4.3.

```
[DEPRECATED] The `--with` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local with 'development'`, and stop using this flag
```

While the intention is apparently to restrict installed gems to development group, it makes no difference to the resulting installation set. 

This is because we cannot rely on `--with` to opt out from installing grouped gems. What we might want to use is either `--without` option or `group :test, optional: true`. A relevant reference is here:
https://bundler.io/guides/groups.html#optional-groups-and-bundlewith

Here I propose that we drop the irrelevant flag. The discussion above in turn shows that  `gem 'simplecov'` does not need to reside in test group, as it's been, and will be, installed regardless of the presence of `--with`. Therefore it's got rid of as well.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
