### PR TITLE
fix: match only against the end of a file path.

### DIFF
--- a/lib/twilio-ruby/rest.rb
+++ b/lib/twilio-ruby/rest.rb
@@ -5,7 +5,7 @@ Dir[File.join(__dir__, 'framework/rest/*.rb')].sort.each do |file|
 end
 
 Dir[File.join(__dir__, 'rest/*.rb')].sort.each do |file|
-  require file.gsub('.rb', '_base.rb') unless file.end_with?('client.rb') || file.end_with?('_base.rb')
+  require file.gsub(/\.rb$/, '_base.rb') unless file.end_with?('client.rb') || file.end_with?('_base.rb')
   require file
 end
 


### PR DESCRIPTION
Otherwise if there happens to be `.rb` in a directory name, that'll be incorrectly modified as well.

I haven't added a test as this code is part of loading everything, rather than something that occurs once the library is loaded.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
