### PR TITLE
fix: #663 local jump error due to lack of block passing for recording list

### DIFF
--- a/lib/twilio-ruby/rest/video/v1/recording.rb
+++ b/lib/twilio-ruby/rest/video/v1/recording.rb
@@ -126,7 +126,7 @@ module Twilio
                             
                             'SourceSid' => source_sid,
                             
-                            'GroupingSid' =>  Twilio.serialize_list(grouping_sid),
+                            'GroupingSid' =>  Twilio.serialize_list(grouping_sid) { |e| e },
                             
                             'DateCreatedAfter' =>  Twilio.serialize_iso8601_datetime(date_created_after),
                             


### PR DESCRIPTION
Fix local jump error due to lack of block passing for recording list.

Fixes
https://github.com/twilio/twilio-ruby/issues/663

It appears after a recent merge that the block passed to the seralize_list method was removed in the recordings file:
https://github.com/JYorston/twilio-ruby/commit/1956b94a670527a2886d64ac72a596e84247b4f5

This is causing a local_jump_error when trying to list recordings on the latest Gem version.

I added the block back in and verified that it is now working as expected.

Checklist

- [x]  I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.