### PR TITLE
Chore: Support JWT 3.x

### DIFF
--- a/twilio-ruby.gemspec
+++ b/twilio-ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['README.md', 'LICENSE']
   spec.rdoc_options = ['--line-numbers', '--inline-source', '--title', 'twilio-ruby', '--main', 'README.md']
 
-  spec.add_dependency('jwt', '>= 1.5', '< 3.0')
+  spec.add_dependency('jwt', '>= 1.5', '< 4.0')
   spec.add_dependency('nokogiri', '>= 1.6', '< 2.0')
   spec.add_dependency('faraday', '>= 0.9', '< 3.0')
   # Workaround for RBX <= 2.2.1, should be fixed in next version


### PR DESCRIPTION
# Fixes #

[JWT 3.0 was released 2 weeks ago](https://github.com/jwt/ruby-jwt/releases/tag/v3.0.0), it doesn't seem to break any functionalities in this gem so I think it should be fine to loosen the restriction.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
